### PR TITLE
Add interactive board layout editor with save/load and full test coverage

### DIFF
--- a/Chess/board.py
+++ b/Chess/board.py
@@ -17,15 +17,17 @@ except NameError:
 pygame.font.init()
 
 class Board:
-	def __init__(self):
+	def __init__(self, board_size=8):
+		self.board_size = board_size
 		self.pieces_defs = AllPieces().pieces_defs
 		self.en_passant_target = None   # square a pawn just skipped over (ep capture destination)
 		self.promotion_pending = None   # (x, y) of pawn awaiting promotion choice
 		self.new_board()
 
 	def draw_board_squares(self):
-		for x in xrange(8):
-			for y in xrange(8):
+		N = self.board_size
+		for x in xrange(N):
+			for y in xrange(N):
 				color = Colours.CREAM if (x + y) % 2 == 0 else Colours.BROWN
 				self.matrix[int(y)][int(x)] = Square(color, (x, y))
 
@@ -35,8 +37,8 @@ class Board:
 		"""
 
 		# initialize squares and place them in matrix
-
-		self.matrix = [[None] * 8 for i in xrange(8)]
+		N = self.board_size
+		self.matrix = [[None] * N for i in xrange(N)]
 
 		# initialize the board squares
 		self.draw_board_squares()
@@ -44,13 +46,14 @@ class Board:
 		self.en_passant_target = None
 		self.promotion_pending = None
 
-		# initialize chess pieces in starting positions
+		# initialize chess pieces in starting positions (back ranks at rows 0 and N-1)
 		back_rank = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook']
-		for x in xrange(8):
-			self.matrix[x][0].occupant = Piece(Colours.PIECE_BLACK, back_rank[x])
+		for x in xrange(N):
+			piece_type = back_rank[x] if x < len(back_rank) else 'pawn'
+			self.matrix[x][0].occupant = Piece(Colours.PIECE_BLACK, piece_type)
 			self.matrix[x][1].occupant = Piece(Colours.PIECE_BLACK, 'pawn')
-			self.matrix[x][6].occupant = Piece(Colours.WHITE, 'pawn')
-			self.matrix[x][7].occupant = Piece(Colours.WHITE, back_rank[x])
+			self.matrix[x][N - 2].occupant = Piece(Colours.WHITE, 'pawn')
+			self.matrix[x][N - 1].occupant = Piece(Colours.WHITE, piece_type)
 
 
 	def rel(self, dir, coord_tuple):
@@ -116,7 +119,8 @@ class Board:
 			piece_color=piece.color,
 			board_matrix=self.matrix,
 			piece_defs=self.pieces_defs,
-			white_color=Colours.WHITE
+			white_color=Colours.WHITE,
+			board_size=self.board_size
 		).legal
 		moves += self._castling_destinations(coord_tuple)
 		moves += self._en_passant_moves(coord_tuple)
@@ -224,8 +228,9 @@ class Board:
 		>>> board.on_board(3, 9):
 		False
 		"""
+		N = self.board_size
 		x, y = coord_tuple
-		if x < 0 or y < 0 or x > 7 or y > 7:
+		if x < 0 or y < 0 or x >= N or y >= N:
 			return False
 		else:
 			return True
@@ -242,7 +247,7 @@ class Board:
 		if piece is None:
 			return
 		if piece.piece_type == 'pawn':
-			back_rank = 0 if piece.color == Colours.WHITE else 7
+			back_rank = 0 if piece.color == Colours.WHITE else self.board_size - 1
 			if y == back_rank:
 				self.promotion_pending = (x, y)
 
@@ -264,10 +269,11 @@ class Board:
 		if self.is_in_check(piece.color):
 			return []
 
+		N = self.board_size
 		destinations = []
 		# (rook_col, king_destination_col, transit_col)
-		for rook_x, king_dest_x, transit_x in [(7, x + 2, x + 1), (0, x - 2, x - 1)]:
-			if not (0 <= king_dest_x <= 7):
+		for rook_x, king_dest_x, transit_x in [(N - 1, x + 2, x + 1), (0, x - 2, x - 1)]:
+			if not (0 <= king_dest_x < N):
 				continue
 			# King cannot castle to a hole square
 			if self.matrix[king_dest_x][y].is_hole:
@@ -313,8 +319,9 @@ class Board:
 
 	def find_king(self, color):
 		"""Returns (x, y) of the king belonging to `color`, or None."""
-		for x in xrange(8):
-			for y in xrange(8):
+		N = self.board_size
+		for x in xrange(N):
+			for y in xrange(N):
 				piece = self.matrix[x][y].occupant
 				if piece and piece.color == color and piece.piece_type == 'king':
 					return (x, y)
@@ -325,8 +332,9 @@ class Board:
 		king_pos = self.find_king(color)
 		if king_pos is None:
 			return False
-		for x in xrange(8):
-			for y in xrange(8):
+		N = self.board_size
+		for x in xrange(N):
+			for y in xrange(N):
 				piece = self.matrix[x][y].occupant
 				if piece and piece.color != color:
 					if king_pos in PieceMoves(
@@ -335,7 +343,8 @@ class Board:
 						piece_color=piece.color,
 						board_matrix=self.matrix,
 						piece_defs=self.pieces_defs,
-						white_color=Colours.WHITE
+						white_color=Colours.WHITE,
+						board_size=self.board_size
 					).legal:
 						return True
 		return False
@@ -404,10 +413,11 @@ class Board:
 
 	def to_dict(self):
 		"""Serialise the full board state to a JSON-compatible dict."""
+		N = self.board_size
 		matrix_data = []
-		for x in xrange(8):
+		for x in xrange(N):
 			col = []
-			for y in xrange(8):
+			for y in xrange(N):
 				sq = self.matrix[x][y]
 				if sq.is_hole:
 					col.append('hole')
@@ -421,6 +431,7 @@ class Board:
 					})
 			matrix_data.append(col)
 		return {
+			'board_size': self.board_size,
 			'matrix': matrix_data,
 			'en_passant_target': list(self.en_passant_target) if self.en_passant_target else None,
 			'promotion_pending': list(self.promotion_pending) if self.promotion_pending else None,
@@ -428,6 +439,9 @@ class Board:
 
 	def from_dict(self, d):
 		"""Restore board state from a dict produced by to_dict()."""
+		self.board_size = d.get('board_size', 8)
+		N = self.board_size
+		self.matrix = [[None] * N for i in xrange(N)]
 		self.draw_board_squares()
 		self.en_passant_target = tuple(d['en_passant_target']) if d.get('en_passant_target') else None
 		self.promotion_pending = tuple(d['promotion_pending']) if d.get('promotion_pending') else None

--- a/Chess/board.py
+++ b/Chess/board.py
@@ -404,14 +404,16 @@ class Board:
 		for x in xrange(8):
 			col = []
 			for y in xrange(8):
-				piece = self.matrix[x][y].occupant
-				if piece is None:
+				sq = self.matrix[x][y]
+				if sq.is_hole:
+					col.append('hole')
+				elif sq.occupant is None:
 					col.append(None)
 				else:
 					col.append({
-						'piece_type': piece.piece_type,
-						'color': self._color_to_str(piece.color),
-						'has_moved': piece.has_moved,
+						'piece_type': sq.occupant.piece_type,
+						'color': self._color_to_str(sq.occupant.color),
+						'has_moved': sq.occupant.has_moved,
 					})
 			matrix_data.append(col)
 		return {
@@ -427,7 +429,10 @@ class Board:
 		self.promotion_pending = tuple(d['promotion_pending']) if d.get('promotion_pending') else None
 		for x, col in enumerate(d['matrix']):
 			for y, cell in enumerate(col):
-				if cell is not None:
+				if cell == 'hole':
+					self.matrix[x][y].is_hole = True
+					self.matrix[x][y].color = Colours.HOLE
+				elif cell is not None:
 					p = Piece(self._str_to_color(cell['color']), cell['piece_type'])
 					p.has_moved = cell['has_moved']
 					self.matrix[x][y].occupant = p
@@ -441,7 +446,8 @@ class Piece:
 		self.has_moved = False   # used for castling eligibility
 
 class Square:
-	def __init__(self, color, coords, occupant=None):
+	def __init__(self, color, coords, occupant=None, is_hole=False):
 		self.color = color # color is either BLACK or WHITE
 		self.occupant = occupant # occupant is a Square object
 		self.coords = coords
+		self.is_hole = is_hole   # True → disabled square (pieces cannot enter)

--- a/Chess/board.py
+++ b/Chess/board.py
@@ -269,12 +269,16 @@ class Board:
 		for rook_x, king_dest_x, transit_x in [(7, x + 2, x + 1), (0, x - 2, x - 1)]:
 			if not (0 <= king_dest_x <= 7):
 				continue
+			# King cannot castle to a hole square
+			if self.matrix[king_dest_x][y].is_hole:
+				continue
 			rook = self.matrix[rook_x][y].occupant
 			if rook is None or rook.piece_type != 'rook' or rook.has_moved:
 				continue
-			# All squares between king and rook must be empty
+			# All squares between king and rook must be empty and not holes
 			lo, hi = min(x, rook_x) + 1, max(x, rook_x)
-			if any(self.matrix[bx][y].occupant is not None for bx in xrange(lo, hi)):
+			if any(self.matrix[bx][y].occupant is not None or self.matrix[bx][y].is_hole
+				   for bx in xrange(lo, hi)):
 				continue
 			# King must not pass through a square that is under attack
 			captured = self._simulate_move((x, y), (transit_x, y))

--- a/Chess/common.py
+++ b/Chess/common.py
@@ -9,6 +9,7 @@ class Colours:
     CREAM = (240, 217, 181)
     BROWN = (181, 136,  99)
     PIECE_BLACK = ( 30,  30,  30)
+    HOLE = ( 65,  65,  75)   # sunken grey for disabled/hole squares
 
 class Directions:
     ##DIRECTIONS##

--- a/Chess/game.py
+++ b/Chess/game.py
@@ -362,12 +362,20 @@ class Graphics:
 
     def draw_board_squares(self, board):
         """
-        Takes a board object and draws all of its squares to the display
+        Takes a board object and draws all of its squares to the display.
+        Hole squares are drawn in HOLE grey with a darker inset for a sunken look.
         """
+        sq = self.square_size
         for x in xrange(8):
             for y in xrange(8):
-                pygame.draw.rect(self.screen, board.matrix[int(x)][int(y)].color,
-                                 (x * self.square_size, y * self.square_size, self.square_size, self.square_size), )
+                sq_obj = board.matrix[int(x)][int(y)]
+                pygame.draw.rect(self.screen, sq_obj.color,
+                                 (x * sq, y * sq, sq, sq))
+                if sq_obj.is_hole:
+                    inset = 3
+                    pygame.draw.rect(self.screen, (45, 45, 55),
+                                     (x * sq + inset, y * sq + inset,
+                                      sq - inset * 2, sq - inset * 2))
 
     def draw_board_pieces(self, board):
         """
@@ -1069,7 +1077,9 @@ class BoardLayoutEditor:
         return None
 
     def _palette_rects(self):
-        """Return list of (color_str, piece_type, pygame.Rect) for the palette."""
+        """Return list of (color_str, piece_type, pygame.Rect) for the palette.
+        The last entry is the hole tool: ('hole', 'hole', rect).
+        """
         px = self._panel_x()
         pw = self.w - px - self.PADDING
         item_h = 30
@@ -1082,6 +1092,9 @@ class BoardLayoutEditor:
                                pygame.Rect(px, y, pw, item_h)))
                 y += item_h + gap
             y += gap * 3  # extra gap between colour sections
+        # Hole tool — separate section at the bottom of the palette
+        y += gap * 2
+        rects.append(('hole', 'hole', pygame.Rect(px, y, pw, item_h)))
         return rects
 
     def _button_rects(self, btn_y, btn_h):
@@ -1132,32 +1145,36 @@ class BoardLayoutEditor:
                 if event.type == locals.MOUSEBUTTONDOWN:
                     mx, my = event.pos
 
-                    # Board click: place or remove a piece
+                    # Board click: place/remove piece or toggle hole
                     sq_coord = self._board_sq_from_pixel(mx, my)
                     if sq_coord is not None:
                         bx, by = sq_coord
                         cell = layout['matrix'][bx][by]
                         if event.button == 3:
-                            # Right-click: always clear
+                            # Right-click: always clear (removes pieces and holes)
                             layout['matrix'][bx][by] = None
                         elif event.button == 1:
-                            color_str, piece_type = selected
-                            if (cell is not None
-                                    and cell['piece_type'] == piece_type
-                                    and cell['color'] == color_str):
-                                # Same piece clicked again → remove
-                                layout['matrix'][bx][by] = None
+                            if selected == 'hole':
+                                # Toggle hole: punch in or restore to empty
+                                layout['matrix'][bx][by] = None if cell == 'hole' else 'hole'
                             else:
-                                layout['matrix'][bx][by] = {
-                                    'piece_type': piece_type,
-                                    'color': color_str,
-                                    'has_moved': False,
-                                }
+                                color_str, piece_type = selected
+                                if (isinstance(cell, dict)
+                                        and cell['piece_type'] == piece_type
+                                        and cell['color'] == color_str):
+                                    # Same piece clicked again → remove
+                                    layout['matrix'][bx][by] = None
+                                else:
+                                    layout['matrix'][bx][by] = {
+                                        'piece_type': piece_type,
+                                        'color': color_str,
+                                        'has_moved': False,
+                                    }
 
                     # Palette click: change selection
                     for color_str, piece_type, rect in self._palette_rects():
                         if rect.collidepoint(mx, my):
-                            selected = (color_str, piece_type)
+                            selected = 'hole' if color_str == 'hole' else (color_str, piece_type)
 
                     # Button clicks
                     for label, rect in self._button_rects(btn_y, btn_h).items():
@@ -1231,12 +1248,21 @@ class BoardLayoutEditor:
         # Board squares
         for x in range(8):
             for y in range(8):
-                color = self.CREAM if (x + y) % 2 == 0 else self.BROWN
+                cell = layout['matrix'][x][y]
+                if cell == 'hole':
+                    base_color = Colours.HOLE
+                else:
+                    base_color = self.CREAM if (x + y) % 2 == 0 else self.BROWN
                 rect = self._board_sq_rect(x, y)
                 sq_coord = self._board_sq_from_pixel(*mouse)
-                if sq_coord == (x, y):
-                    color = tuple(min(c + 30, 255) for c in color)
-                pygame.draw.rect(self.screen, color, rect)
+                if sq_coord == (x, y) and cell != 'hole':
+                    base_color = tuple(min(c + 30, 255) for c in base_color)
+                pygame.draw.rect(self.screen, base_color, rect)
+                if cell == 'hole':
+                    inset = 3
+                    pygame.draw.rect(self.screen, (45, 45, 55),
+                                     pygame.Rect(rect.left + inset, rect.top + inset,
+                                                 rect.w - inset * 2, rect.h - inset * 2))
 
         # Board pieces
         piece_labels = {'pawn': 'P', 'rook': 'R', 'knight': 'N',
@@ -1244,7 +1270,7 @@ class BoardLayoutEditor:
         for x in range(8):
             for y in range(8):
                 cell = layout['matrix'][x][y]
-                if cell is None:
+                if cell is None or cell == 'hole':
                     continue
                 rect = self._board_sq_rect(x, y)
                 cx, cy = rect.centerx, rect.centery
@@ -1277,7 +1303,9 @@ class BoardLayoutEditor:
         self.screen.blit(pal_hdr, (px, oy + 6))
 
         for color_str, piece_type, rect in self._palette_rects():
-            is_sel = selected == (color_str, piece_type)
+            is_hole_entry = (color_str == 'hole')
+            is_sel = (selected == 'hole' if is_hole_entry
+                      else selected == (color_str, piece_type))
             hov    = rect.collidepoint(*mouse)
             if is_sel:
                 bg = self.HIGH
@@ -1290,14 +1318,22 @@ class BoardLayoutEditor:
                 tc = self.TEXT
             pygame.draw.rect(self.screen, bg, rect, border_radius=5)
 
-            # Mini icon in the palette row
-            icon = self.piece_icons.get((piece_type, color_str))
             icon_x = rect.left + 4
-            if icon:
-                small = pygame.transform.smoothscale(icon, (24, 24))
-                self.screen.blit(small, small.get_rect(centery=rect.centery, left=icon_x))
-            lbl_text = f"{color_str}  {piece_type}"
-            lbl = self.small_font.render(lbl_text, True, tc)
+            if is_hole_entry:
+                # Draw a small grey swatch for the hole tool
+                swatch = pygame.Rect(icon_x, rect.centery - 10, 24, 20)
+                pygame.draw.rect(self.screen, Colours.HOLE, swatch, border_radius=2)
+                pygame.draw.rect(self.screen, (45, 45, 55),
+                                 swatch.inflate(-6, -6), border_radius=1)
+                lbl = self.small_font.render('Hole  (toggle)', True, tc)
+            else:
+                # Mini piece icon in the palette row
+                icon = self.piece_icons.get((piece_type, color_str))
+                if icon:
+                    small = pygame.transform.smoothscale(icon, (24, 24))
+                    self.screen.blit(small, small.get_rect(centery=rect.centery, left=icon_x))
+                lbl_text = f"{color_str}  {piece_type}"
+                lbl = self.small_font.render(lbl_text, True, tc)
             self.screen.blit(lbl, lbl.get_rect(centery=rect.centery, left=icon_x + 28))
 
         # Bottom buttons

--- a/Chess/game.py
+++ b/Chess/game.py
@@ -1187,6 +1187,17 @@ class BoardLayoutEditor:
                                         'has_moved': False,
                                     }
 
+                    # Board size +/- buttons
+                    minus_rect, plus_rect = self._size_rects(board_size)
+                    if minus_rect.collidepoint(mx, my) and board_size > self.MIN_BOARD_SIZE:
+                        layout = self._resize_layout(layout, board_size - 1)
+                        status_msg = f'Board size: {board_size - 1}×{board_size - 1}'
+                        status_until = pygame.time.get_ticks() + 2000
+                    elif plus_rect.collidepoint(mx, my) and board_size < self.MAX_BOARD_SIZE:
+                        layout = self._resize_layout(layout, board_size + 1)
+                        status_msg = f'Board size: {board_size + 1}×{board_size + 1}'
+                        status_until = pygame.time.get_ticks() + 2000
+
                     # Palette click: change selection
                     for color_str, piece_type, rect in self._palette_rects(board_size):
                         if rect.collidepoint(mx, my):
@@ -1244,6 +1255,44 @@ class BoardLayoutEditor:
         _, oy = self._board_origin()
         preset_btn_h = 32
         return oy + sq * board_size + self.PADDING * 2 + preset_btn_h + 18
+
+    MIN_BOARD_SIZE = 4
+    MAX_BOARD_SIZE = 12
+
+    def _size_rects(self, board_size=8):
+        """Return (minus_rect, plus_rect) for the board-size +/- buttons in the panel."""
+        px = self._panel_x(board_size)
+        pw = self.w - px - self.PADDING
+        btn_w = 28
+        y = 44 + 6   # near top of panel, same baseline as palette header
+        minus_rect = pygame.Rect(px + pw - btn_w * 2 - 4, y, btn_w, 22)
+        plus_rect  = pygame.Rect(px + pw - btn_w,          y, btn_w, 22)
+        return minus_rect, plus_rect
+
+    @staticmethod
+    def _resize_layout(layout, new_size):
+        """
+        Return a new layout dict with board_size=new_size.
+        Cells within the new bounds are preserved; cells outside are dropped.
+        New cells (expanded rows/columns) are filled with None.
+        """
+        old_size = layout.get('board_size', 8)
+        old_matrix = layout['matrix']
+        new_matrix = []
+        for x in range(new_size):
+            col = []
+            for y in range(new_size):
+                if x < old_size and y < old_size:
+                    col.append(old_matrix[x][y])
+                else:
+                    col.append(None)
+            new_matrix.append(col)
+        return {
+            'board_size': new_size,
+            'matrix': new_matrix,
+            'en_passant_target': None,
+            'promotion_pending': None,
+        }
 
     def _preset_rects(self, btn_y, btn_h, board_size=8):
         """Return dict of preset_name → pygame.Rect, above the bottom buttons."""
@@ -1349,6 +1398,22 @@ class BoardLayoutEditor:
                          border_radius=4)
         pal_hdr = self.label_font.render('Palette', True, self.TITLE_COLOR)
         self.screen.blit(pal_hdr, (px, oy + 6))
+
+        # Board size controls: "Size: N  [−] [+]"
+        minus_rect, plus_rect = self._size_rects(board_size)
+        size_lbl = self.tiny_font.render(f'Size: {board_size}', True, self.TEXT)
+        self.screen.blit(size_lbl, size_lbl.get_rect(
+            centery=minus_rect.centery, right=minus_rect.left - 6))
+        for rect, label, enabled in [
+            (minus_rect, '−', board_size > self.MIN_BOARD_SIZE),
+            (plus_rect,  '+', board_size < self.MAX_BOARD_SIZE),
+        ]:
+            hov = rect.collidepoint(*mouse) and enabled
+            bg = self.BTN_HOV if hov else (self.BTN_BG if enabled else (45, 48, 58))
+            tc = self.TEXT if enabled else (70, 75, 85)
+            pygame.draw.rect(self.screen, bg, rect, border_radius=4)
+            t = self.label_font.render(label, True, tc)
+            self.screen.blit(t, t.get_rect(center=rect.center))
 
         for color_str, piece_type, rect in self._palette_rects(board_size):
             is_hole_entry = (color_str == 'hole')

--- a/Chess/game.py
+++ b/Chess/game.py
@@ -42,6 +42,7 @@ class Game:
     def setup(self):
         """Draws the window and board at the beginning of the game"""
         self.graphics.setup_window()
+        self.graphics.set_board_size(self.board.board_size)
         self.graphics.load_piece_icons(self.board.pieces_defs)
 
     def event_loop(self):
@@ -220,7 +221,8 @@ class Graphics:
             (self.window_size, self.window_size + self.button_bar_height)
         )
 
-        self.square_size = self.window_size // 8
+        self.board_size = 8
+        self.square_size = self.window_size // self.board_size
         self.piece_size = self.square_size // 2
         self.piece_font = pygame.font.SysFont(None, self.piece_size)
 
@@ -266,6 +268,13 @@ class Graphics:
                     self.piece_icons[(piece_type, color_name)] = render_svg(svg, (px, px))
                 except Exception:
                     pass
+
+    def set_board_size(self, n):
+        """Update rendering parameters when the board changes size."""
+        self.board_size = n
+        self.square_size = self.window_size // n
+        self.piece_size = self.square_size // 2
+        self.piece_font = pygame.font.SysFont(None, self.piece_size)
 
     def setup_window(self):
         """
@@ -366,8 +375,8 @@ class Graphics:
         Hole squares are drawn in HOLE grey with a darker inset for a sunken look.
         """
         sq = self.square_size
-        for x in xrange(8):
-            for y in xrange(8):
+        for x in xrange(self.board_size):
+            for y in xrange(self.board_size):
                 sq_obj = board.matrix[int(x)][int(y)]
                 pygame.draw.rect(self.screen, sq_obj.color,
                                  (x * sq, y * sq, sq, sq))
@@ -383,8 +392,8 @@ class Graphics:
         Uses icon images when available, falls back to circle+letter otherwise.
         """
         piece_labels = {'pawn': 'P', 'rook': 'R', 'knight': 'N', 'bishop': 'B', 'queen': 'Q', 'king': 'K'}
-        for x in xrange(8):
-            for y in xrange(8):
+        for x in xrange(self.board_size):
+            for y in xrange(self.board_size):
                 piece = board.matrix[int(x)][int(y)].occupant
                 if piece is not None:
                     center = self.pixel_coords((x, y))
@@ -413,8 +422,9 @@ class Graphics:
         Does the reverse of pixel_coords(). Takes in a tuple of of pixel coordinates and returns what square they are in.
         """
         pixel_x, pixel_y = pixel_coords_tuple
-        x = min(max(pixel_x // self.square_size, 0), 7)
-        y = min(max(pixel_y // self.square_size, 0), 7)
+        N = self.board_size - 1
+        x = min(max(pixel_x // self.square_size, 0), N)
+        y = min(max(pixel_y // self.square_size, 0), N)
         return (x, y)
 
     def highlight_squares(self, squares, origin):
@@ -457,24 +467,29 @@ class Graphics:
 
     # Board columns used for the promotion picker (centred on the board)
     PROMOTION_PIECES = ['queen', 'rook', 'bishop', 'knight']
-    PROMOTION_COLS   = [2, 3, 4, 5]   # x indices; row is always 3 (middle)
-    PROMOTION_ROW    = 3
+
+    def _promotion_cols_row(self):
+        """Return (cols_list, row) centred on the current board."""
+        start = (self.board_size - 4) // 2
+        cols = [start + i for i in range(4)]
+        row = self.board_size // 2 - 1
+        return cols, row
 
     def draw_promotion_picker(self, color_key):
         """
         Draws a centred 4-square overlay letting the player pick a promotion piece.
         The four choices are queen / rook / bishop / knight.
         """
-        row = self.PROMOTION_ROW
+        cols, row = self._promotion_cols_row()
         # Dark border behind the four squares
-        border_x = self.PROMOTION_COLS[0] * self.square_size - 4
+        border_x = cols[0] * self.square_size - 4
         border_y = row * self.square_size - 4
-        border_w = len(self.PROMOTION_COLS) * self.square_size + 8
+        border_w = len(cols) * self.square_size + 8
         border_h = self.square_size + 8
         pygame.draw.rect(self.screen, Colours.BLACK,
                          (border_x, border_y, border_w, border_h), border_radius=6)
 
-        for piece_type, col in zip(self.PROMOTION_PIECES, self.PROMOTION_COLS):
+        for piece_type, col in zip(self.PROMOTION_PIECES, cols):
             sx = col * self.square_size
             sy = row * self.square_size
             pygame.draw.rect(self.screen, Colours.HIGH,
@@ -493,10 +508,11 @@ class Graphics:
         Returns the piece type the player clicked in the promotion picker, or None.
         mouse_pos is in board coordinates (col, row).
         """
+        cols, promo_row = self._promotion_cols_row()
         mx, my = mouse_pos
-        if my != self.PROMOTION_ROW:
+        if my != promo_row:
             return None
-        for piece_type, col in zip(self.PROMOTION_PIECES, self.PROMOTION_COLS):
+        for piece_type, col in zip(self.PROMOTION_PIECES, cols):
             if mx == col:
                 return piece_type
         return None
@@ -1020,7 +1036,7 @@ class BoardLayoutEditor:
 
         # Piece icon rendering (for palette + board preview)
         pieces_defs = AllPieces().pieces_defs
-        sq = self._board_sq_size()
+        sq = self._board_sq_size(8)  # icons always cached at standard 8×8 size
         self.piece_icons = {}
         icon_colours = {
             'white': {'fill': '#F0F0E6', 'stroke': '#3C3C3C'},
@@ -1047,40 +1063,40 @@ class BoardLayoutEditor:
     # Geometry
     # ------------------------------------------------------------------
 
-    def _board_sq_size(self):
+    def _board_sq_size(self, board_size=8):
         """Size of each board square in pixels."""
         board_area = self.w * 3 // 4   # board uses left 3/4 of the window
-        return board_area // 8
+        return board_area // board_size
 
     def _board_origin(self):
         """Top-left pixel corner of the board."""
         return (0, 44)
 
-    def _panel_x(self):
-        sq = self._board_sq_size()
+    def _panel_x(self, board_size=8):
+        sq = self._board_sq_size(board_size)
         ox, _ = self._board_origin()
-        return ox + sq * 8 + self.PADDING
+        return ox + sq * board_size + self.PADDING
 
-    def _board_sq_rect(self, x, y):
-        sq = self._board_sq_size()
+    def _board_sq_rect(self, x, y, board_size=8):
+        sq = self._board_sq_size(board_size)
         ox, oy = self._board_origin()
         return pygame.Rect(ox + x * sq, oy + y * sq, sq, sq)
 
-    def _board_sq_from_pixel(self, px, py):
+    def _board_sq_from_pixel(self, px, py, board_size=8):
         """Return (x, y) board coordinate for pixel (px, py), or None if outside."""
-        sq = self._board_sq_size()
+        sq = self._board_sq_size(board_size)
         ox, oy = self._board_origin()
         bx = (px - ox) // sq
         by = (py - oy) // sq
-        if 0 <= bx < 8 and 0 <= by < 8:
+        if 0 <= bx < board_size and 0 <= by < board_size:
             return (bx, by)
         return None
 
-    def _palette_rects(self):
+    def _palette_rects(self, board_size=8):
         """Return list of (color_str, piece_type, pygame.Rect) for the palette.
         The last entry is the hole tool: ('hole', 'hole', rect).
         """
-        px = self._panel_x()
+        px = self._panel_x(board_size)
         pw = self.w - px - self.PADDING
         item_h = 30
         gap    = 4
@@ -1097,10 +1113,10 @@ class BoardLayoutEditor:
         rects.append(('hole', 'hole', pygame.Rect(px, y, pw, item_h)))
         return rects
 
-    def _button_rects(self, btn_y, btn_h):
+    def _button_rects(self, btn_y, btn_h, board_size=8):
         labels = ['← Back', 'Reset', 'Save', 'Play']
-        sq = self._board_sq_size()
-        total_w = sq * 8   # buttons span the board width
+        sq = self._board_sq_size(board_size)
+        total_w = sq * board_size   # buttons span the board width
         bw = (total_w - self.PADDING * (len(labels) - 1)) // len(labels)
         ox, _ = self._board_origin()
         rects = {}
@@ -1128,11 +1144,11 @@ class BoardLayoutEditor:
         clock = pygame.time.Clock()
 
         while True:
+            board_size = layout.get('board_size', 8)
             mouse = pygame.mouse.get_pos()
-            sq = self._board_sq_size()
             _, oy = self._board_origin()
             btn_h  = 40
-            btn_y  = oy + sq * 8 + self.PADDING
+            btn_y  = self._btn_y(board_size)
 
             for event in pygame.event.get():
                 if event.type == locals.QUIT:
@@ -1146,7 +1162,7 @@ class BoardLayoutEditor:
                     mx, my = event.pos
 
                     # Board click: place/remove piece or toggle hole
-                    sq_coord = self._board_sq_from_pixel(mx, my)
+                    sq_coord = self._board_sq_from_pixel(mx, my, board_size)
                     if sq_coord is not None:
                         bx, by = sq_coord
                         cell = layout['matrix'][bx][by]
@@ -1172,12 +1188,19 @@ class BoardLayoutEditor:
                                     }
 
                     # Palette click: change selection
-                    for color_str, piece_type, rect in self._palette_rects():
+                    for color_str, piece_type, rect in self._palette_rects(board_size):
                         if rect.collidepoint(mx, my):
                             selected = 'hole' if color_str == 'hole' else (color_str, piece_type)
 
+                    # Preset button clicks
+                    for preset_name, rect in self._preset_rects(btn_y, btn_h, board_size).items():
+                        if rect.collidepoint(mx, my):
+                            layout = self._make_preset(preset_name)
+                            status_msg = f'Loaded preset: {preset_name}'
+                            status_until = pygame.time.get_ticks() + 2500
+
                     # Button clicks
-                    for label, rect in self._button_rects(btn_y, btn_h).items():
+                    for label, rect in self._button_rects(btn_y, btn_h, board_size).items():
                         if rect.collidepoint(mx, my):
                             if label == '← Back':
                                 return layout, saved_path
@@ -1205,14 +1228,37 @@ class BoardLayoutEditor:
 
     def _default_layout(self):
         """Return the standard chess starting position as a layout dict."""
-        back_rank = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook']
-        matrix = [[None] * 8 for _ in range(8)]
-        for x in range(8):
-            matrix[x][0] = {'piece_type': back_rank[x], 'color': 'black', 'has_moved': False}
-            matrix[x][1] = {'piece_type': 'pawn',        'color': 'black', 'has_moved': False}
-            matrix[x][6] = {'piece_type': 'pawn',        'color': 'white', 'has_moved': False}
-            matrix[x][7] = {'piece_type': back_rank[x],  'color': 'white', 'has_moved': False}
-        return {'matrix': matrix, 'en_passant_target': None, 'promotion_pending': None}
+        return _preset_standard()
+
+    def _make_preset(self, name):
+        """Return a preset layout dict by name."""
+        if name == 'Triangle 8×8':
+            return _preset_triangle()
+        elif name == 'Hexagon 12×12':
+            return _preset_hexagon()
+        return _preset_standard()
+
+    def _btn_y(self, board_size=8):
+        """Return the y-pixel of the action buttons row (consistent with run())."""
+        sq = self._board_sq_size(board_size)
+        _, oy = self._board_origin()
+        preset_btn_h = 32
+        return oy + sq * board_size + self.PADDING * 2 + preset_btn_h + 18
+
+    def _preset_rects(self, btn_y, btn_h, board_size=8):
+        """Return dict of preset_name → pygame.Rect, above the bottom buttons."""
+        names = ['Standard 8×8', 'Triangle 8×8', 'Hexagon 12×12']
+        sq = self._board_sq_size(board_size)
+        ox, _ = self._board_origin()
+        total_w = sq * board_size
+        preset_btn_h = 32
+        preset_y = btn_y - preset_btn_h - self.PADDING
+        bw = (total_w - self.PADDING * (len(names) - 1)) // len(names)
+        rects = {}
+        for i, name in enumerate(names):
+            x = ox + i * (bw + self.PADDING)
+            rects[name] = pygame.Rect(x, preset_y, bw, preset_btn_h)
+        return rects
 
     def _load_or_default(self):
         if os.path.exists(_CUSTOM_LAYOUT_PATH):
@@ -1233,6 +1279,7 @@ class BoardLayoutEditor:
     # ------------------------------------------------------------------
 
     def _draw(self, layout, selected, mouse, btn_y, btn_h, status_msg):
+        board_size = layout.get('board_size', 8)
         self.screen.fill(self.BG)
 
         # Title
@@ -1240,21 +1287,21 @@ class BoardLayoutEditor:
         self.screen.blit(title, (self.PADDING, 8))
         hint = self.tiny_font.render('Left-click: place  •  Right-click: clear  •  Esc: back',
                                      True, self.DIM_TEXT)
-        self.screen.blit(hint, (self._panel_x(), 8))
+        self.screen.blit(hint, (self._panel_x(board_size), 8))
 
-        sq = self._board_sq_size()
+        sq = self._board_sq_size(board_size)
         ox, oy = self._board_origin()
 
         # Board squares
-        for x in range(8):
-            for y in range(8):
+        for x in range(board_size):
+            for y in range(board_size):
                 cell = layout['matrix'][x][y]
                 if cell == 'hole':
                     base_color = Colours.HOLE
                 else:
                     base_color = self.CREAM if (x + y) % 2 == 0 else self.BROWN
-                rect = self._board_sq_rect(x, y)
-                sq_coord = self._board_sq_from_pixel(*mouse)
+                rect = self._board_sq_rect(x, y, board_size)
+                sq_coord = self._board_sq_from_pixel(*mouse, board_size)
                 if sq_coord == (x, y) and cell != 'hole':
                     base_color = tuple(min(c + 30, 255) for c in base_color)
                 pygame.draw.rect(self.screen, base_color, rect)
@@ -1267,17 +1314,18 @@ class BoardLayoutEditor:
         # Board pieces
         piece_labels = {'pawn': 'P', 'rook': 'R', 'knight': 'N',
                         'bishop': 'B', 'queen': 'Q', 'king': 'K'}
-        for x in range(8):
-            for y in range(8):
+        for x in range(board_size):
+            for y in range(board_size):
                 cell = layout['matrix'][x][y]
                 if cell is None or cell == 'hole':
                     continue
-                rect = self._board_sq_rect(x, y)
+                rect = self._board_sq_rect(x, y, board_size)
                 cx, cy = rect.centerx, rect.centery
                 color_key = cell['color']
                 icon = self.piece_icons.get((cell['piece_type'], color_key))
                 if icon:
-                    self.screen.blit(icon, icon.get_rect(center=(cx, cy)))
+                    icon_scaled = pygame.transform.smoothscale(icon, (sq - 6, sq - 6))
+                    self.screen.blit(icon_scaled, icon_scaled.get_rect(center=(cx, cy)))
                 else:
                     c = Colours.WHITE if color_key == 'white' else Colours.PIECE_BLACK
                     r = sq // 2 - 2
@@ -1290,10 +1338,10 @@ class BoardLayoutEditor:
 
         # Board border
         pygame.draw.rect(self.screen, (80, 85, 100),
-                         pygame.Rect(ox, oy, sq * 8, sq * 8), 2)
+                         pygame.Rect(ox, oy, sq * board_size, sq * board_size), 2)
 
         # Right panel — palette
-        px = self._panel_x()
+        px = self._panel_x(board_size)
         pw = self.w - px - self.PADDING
         pygame.draw.rect(self.screen, self.PANEL_BG,
                          pygame.Rect(px - self.PADDING // 2, oy,
@@ -1302,7 +1350,7 @@ class BoardLayoutEditor:
         pal_hdr = self.label_font.render('Palette', True, self.TITLE_COLOR)
         self.screen.blit(pal_hdr, (px, oy + 6))
 
-        for color_str, piece_type, rect in self._palette_rects():
+        for color_str, piece_type, rect in self._palette_rects(board_size):
             is_hole_entry = (color_str == 'hole')
             is_sel = (selected == 'hole' if is_hole_entry
                       else selected == (color_str, piece_type))
@@ -1336,14 +1384,27 @@ class BoardLayoutEditor:
                 lbl = self.small_font.render(lbl_text, True, tc)
             self.screen.blit(lbl, lbl.get_rect(centery=rect.centery, left=icon_x + 28))
 
-        # Bottom buttons
+        # Preset buttons (row above the action buttons)
+        preset_rects = self._preset_rects(btn_y, btn_h, board_size)
+        preset_lbl = self.tiny_font.render('Presets:', True, self.DIM_TEXT)
+        if preset_rects:
+            first_rect = next(iter(preset_rects.values()))
+            self.screen.blit(preset_lbl, (ox, first_rect.y - 18))
+        for name, rect in preset_rects.items():
+            hov = rect.collidepoint(*mouse)
+            bg = self.BTN_HOV if hov else self.BTN_BG
+            pygame.draw.rect(self.screen, bg, rect, border_radius=6)
+            txt = self.tiny_font.render(name, True, self.TEXT)
+            self.screen.blit(txt, txt.get_rect(center=rect.center))
+
+        # Bottom action buttons
         btn_colors = {
             '← Back': self.BTN_BG,
             'Reset':   self.BTN_RST,
             'Save':    self.BTN_SAVE,
             'Play':    self.BTN_PLAY,
         }
-        for label, rect in self._button_rects(btn_y, btn_h).items():
+        for label, rect in self._button_rects(btn_y, btn_h, board_size).items():
             hov = rect.collidepoint(*mouse)
             base = btn_colors[label]
             bg = tuple(min(c + 25, 255) for c in base) if hov else base
@@ -1355,6 +1416,95 @@ class BoardLayoutEditor:
         if status_msg:
             sm = self.small_font.render(status_msg, True, Colours.GOLD)
             self.screen.blit(sm, (ox, btn_y - 22))
+
+
+def _make_layout(board_size, matrix):
+    """Build a layout dict with the given board_size and matrix."""
+    return {'board_size': board_size, 'matrix': matrix,
+            'en_passant_target': None, 'promotion_pending': None}
+
+
+def _preset_standard():
+    """Standard chess starting position on an 8×8 board."""
+    back_rank = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook']
+    matrix = [[None] * 8 for _ in range(8)]
+    for x in range(8):
+        matrix[x][0] = {'piece_type': back_rank[x], 'color': 'black', 'has_moved': False}
+        matrix[x][1] = {'piece_type': 'pawn',        'color': 'black', 'has_moved': False}
+        matrix[x][6] = {'piece_type': 'pawn',        'color': 'white', 'has_moved': False}
+        matrix[x][7] = {'piece_type': back_rank[x],  'color': 'white', 'has_moved': False}
+    return _make_layout(8, matrix)
+
+
+def _preset_triangle():
+    """
+    Triangle board on 8×8.  Holes where x + y < 7 leave a lower-right triangle
+    (36 playable squares).  White starts along the bottom row and right pawns;
+    Black starts along the right column.
+    """
+    N = 8
+    matrix = [['hole'] * N for _ in range(N)]
+    # Clear holes for the playable triangle
+    for x in range(N):
+        for y in range(N):
+            if x + y >= N - 1:
+                matrix[x][y] = None
+
+    # White back rank at y=7 (all 8 squares are in the triangle)
+    white_back = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook']
+    for x in range(N):
+        matrix[x][7] = {'piece_type': white_back[x], 'color': 'white', 'has_moved': False}
+    # White pawns at y=6, x=1..7 (x=0,y=6 is a hole since 0+6=6 < 7)
+    for x in range(1, N):
+        matrix[x][6] = {'piece_type': 'pawn', 'color': 'white', 'has_moved': False}
+
+    # Black back rank along x=7, y=0..6
+    black_back = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight']
+    for y in range(7):
+        matrix[7][y] = {'piece_type': black_back[y], 'color': 'black', 'has_moved': False}
+    # Black pawns at x=6, y=1..6 (x=6,y=0 is a hole since 6+0=6 < 7)
+    for y in range(1, 7):
+        matrix[6][y] = {'piece_type': 'pawn', 'color': 'black', 'has_moved': False}
+
+    return _make_layout(N, matrix)
+
+
+def _preset_hexagon():
+    """
+    Approximate hexagon on a 12×12 board.
+    Holes where: x+y < 3, x+y > 19, x-y > 8, or y-x > 8.
+    Pieces on the valid back ranks at y=11 (white) and y=0 (black).
+    """
+    N = 12
+    matrix = [[None] * N for _ in range(N)]
+
+    def is_hole(x, y):
+        return x + y < 3 or x + y > 19 or x - y > 8 or y - x > 8
+
+    for x in range(N):
+        for y in range(N):
+            if is_hole(x, y):
+                matrix[x][y] = 'hole'
+
+    # White back rank at y=11 — valid x=3..8
+    white_back = ['rook', 'knight', 'bishop', 'queen', 'king', 'rook']
+    for i, x in enumerate(range(3, 9)):
+        matrix[x][11] = {'piece_type': white_back[i], 'color': 'white', 'has_moved': False}
+    # White pawns at y=10 — valid x=2..9
+    for x in range(2, 10):
+        if not is_hole(x, 10):
+            matrix[x][10] = {'piece_type': 'pawn', 'color': 'white', 'has_moved': False}
+
+    # Black back rank at y=0 — valid x=3..8
+    black_back = ['rook', 'knight', 'bishop', 'queen', 'king', 'rook']
+    for i, x in enumerate(range(3, 9)):
+        matrix[x][0] = {'piece_type': black_back[i], 'color': 'black', 'has_moved': False}
+    # Black pawns at y=1 — valid x=2..9
+    for x in range(2, 10):
+        if not is_hole(x, 1):
+            matrix[x][1] = {'piece_type': 'pawn', 'color': 'black', 'has_moved': False}
+
+    return _make_layout(N, matrix)
 
 
 def _start_menu(screen, w, h):
@@ -1455,6 +1605,7 @@ def main():
                 game.board.pieces_defs = custom_defs
             if custom_layout is not None:
                 game.board.from_dict(custom_layout)
+                game.graphics.set_board_size(game.board.board_size)
             game.main()
 
 

--- a/Chess/game.py
+++ b/Chess/game.py
@@ -496,6 +496,7 @@ class Graphics:
 
 _CUSTOM_PIECES_PATH = os.path.join(os.path.dirname(__file__), 'defs', 'custom_pieces.json')
 _DEFAULT_PIECES_PATH = os.path.join(os.path.dirname(__file__), 'defs', 'pieces_defs.json')
+_CUSTOM_LAYOUT_PATH = os.path.join(os.path.dirname(__file__), 'defs', 'custom_layout.json')
 
 # Boolean flags that can be toggled per move_rule
 _RULE_FLAGS = ['sliding', 'directional', 'move_only', 'capture_only', 'jump_capture']
@@ -964,21 +965,390 @@ class PieceEditor:
             self.screen.blit(sm, (self.PADDING, btn_y - 28))
 
 
+class BoardLayoutEditor:
+    """
+    Interactive board layout editor.
+
+    Left side: 8×8 chess board showing the current starting layout.
+    Right panel: piece palette — click a colour+type to select, then click
+                 a board square to place it.  Click an occupied square with
+                 the same piece selected to remove it.  Right-click any
+                 square to clear it.
+
+    Bottom buttons: ← Back / Reset / Save / Play.
+    Saved layout is written to defs/custom_layout.json and loaded by
+    Board.new_board() whenever that file exists.
+    """
+
+    BG       = (25, 28, 38)
+    PANEL_BG = (38, 42, 56)
+    TEXT     = (210, 215, 225)
+    DIM_TEXT = (120, 130, 145)
+    BTN_BG   = (55, 62, 80)
+    BTN_HOV  = (80, 90, 110)
+    BTN_SAVE = (60, 130, 80)
+    BTN_PLAY = (60, 100, 160)
+    BTN_RST  = (140, 70, 60)
+    TITLE_COLOR = Colours.GOLD
+    CREAM    = Colours.CREAM
+    BROWN    = Colours.BROWN
+    HIGH     = Colours.HIGH
+    PADDING  = 14
+
+    # Piece types in palette order
+    PALETTE_PIECES = ['king', 'queen', 'rook', 'bishop', 'knight', 'pawn']
+
+    def __init__(self):
+        pygame.init()
+        info = pygame.display.Info()
+        self.w = min(info.current_w, info.current_h)
+        self.h = self.w
+        self.screen = pygame.display.set_mode((self.w, self.h))
+        pygame.display.set_caption('megaChess — board layout editor')
+        self.title_font = pygame.font.Font('freesansbold.ttf', 28)
+        self.label_font = pygame.font.Font('freesansbold.ttf', 18)
+        self.small_font = pygame.font.Font('freesansbold.ttf', 14)
+        self.tiny_font  = pygame.font.Font('freesansbold.ttf', 12)
+
+        # Piece icon rendering (for palette + board preview)
+        pieces_defs = AllPieces().pieces_defs
+        sq = self._board_sq_size()
+        self.piece_icons = {}
+        icon_colours = {
+            'white': {'fill': '#F0F0E6', 'stroke': '#3C3C3C'},
+            'black': {'fill': '#281E1E', 'stroke': '#C8C8C8'},
+        }
+        for piece_type, defn in pieces_defs.items():
+            path = defn.get('icon')
+            if not path:
+                continue
+            try:
+                template = open(path).read()
+            except (FileNotFoundError, OSError):
+                continue
+            for color_name, colours in icon_colours.items():
+                try:
+                    svg = template.replace('{fill}', colours['fill']) \
+                                  .replace('{stroke}', colours['stroke'])
+                    px = sq - 6
+                    self.piece_icons[(piece_type, color_name)] = render_svg(svg, (px, px))
+                except Exception:
+                    pass
+
+    # ------------------------------------------------------------------
+    # Geometry
+    # ------------------------------------------------------------------
+
+    def _board_sq_size(self):
+        """Size of each board square in pixels."""
+        board_area = self.w * 3 // 4   # board uses left 3/4 of the window
+        return board_area // 8
+
+    def _board_origin(self):
+        """Top-left pixel corner of the board."""
+        return (0, 44)
+
+    def _panel_x(self):
+        sq = self._board_sq_size()
+        ox, _ = self._board_origin()
+        return ox + sq * 8 + self.PADDING
+
+    def _board_sq_rect(self, x, y):
+        sq = self._board_sq_size()
+        ox, oy = self._board_origin()
+        return pygame.Rect(ox + x * sq, oy + y * sq, sq, sq)
+
+    def _board_sq_from_pixel(self, px, py):
+        """Return (x, y) board coordinate for pixel (px, py), or None if outside."""
+        sq = self._board_sq_size()
+        ox, oy = self._board_origin()
+        bx = (px - ox) // sq
+        by = (py - oy) // sq
+        if 0 <= bx < 8 and 0 <= by < 8:
+            return (bx, by)
+        return None
+
+    def _palette_rects(self):
+        """Return list of (color_str, piece_type, pygame.Rect) for the palette."""
+        px = self._panel_x()
+        pw = self.w - px - self.PADDING
+        item_h = 30
+        gap    = 4
+        rects  = []
+        y = 44 + 32  # below "Palette" label
+        for color_str in ('white', 'black'):
+            for piece_type in self.PALETTE_PIECES:
+                rects.append((color_str, piece_type,
+                               pygame.Rect(px, y, pw, item_h)))
+                y += item_h + gap
+            y += gap * 3  # extra gap between colour sections
+        return rects
+
+    def _button_rects(self, btn_y, btn_h):
+        labels = ['← Back', 'Reset', 'Save', 'Play']
+        sq = self._board_sq_size()
+        total_w = sq * 8   # buttons span the board width
+        bw = (total_w - self.PADDING * (len(labels) - 1)) // len(labels)
+        ox, _ = self._board_origin()
+        rects = {}
+        for i, label in enumerate(labels):
+            x = ox + i * (bw + self.PADDING)
+            rects[label] = pygame.Rect(x, btn_y, bw, btn_h)
+        return rects
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def run(self):
+        """
+        Show the editor.  Returns (layout_dict | None, saved_path | None).
+        layout_dict is the board matrix serialised like Board.to_dict(),
+        or None if the default layout should be used.
+        saved_path is set if the user hit Save.
+        """
+        layout = self._load_or_default()
+        selected = ('white', 'pawn')
+        saved_path = None
+        status_msg = ''
+        status_until = 0
+        clock = pygame.time.Clock()
+
+        while True:
+            mouse = pygame.mouse.get_pos()
+            sq = self._board_sq_size()
+            _, oy = self._board_origin()
+            btn_h  = 40
+            btn_y  = oy + sq * 8 + self.PADDING
+
+            for event in pygame.event.get():
+                if event.type == locals.QUIT:
+                    pygame.quit()
+                    sys.exit()
+
+                if event.type == locals.KEYDOWN and event.key == locals.K_ESCAPE:
+                    return layout, saved_path
+
+                if event.type == locals.MOUSEBUTTONDOWN:
+                    mx, my = event.pos
+
+                    # Board click: place or remove a piece
+                    sq_coord = self._board_sq_from_pixel(mx, my)
+                    if sq_coord is not None:
+                        bx, by = sq_coord
+                        cell = layout['matrix'][bx][by]
+                        if event.button == 3:
+                            # Right-click: always clear
+                            layout['matrix'][bx][by] = None
+                        elif event.button == 1:
+                            color_str, piece_type = selected
+                            if (cell is not None
+                                    and cell['piece_type'] == piece_type
+                                    and cell['color'] == color_str):
+                                # Same piece clicked again → remove
+                                layout['matrix'][bx][by] = None
+                            else:
+                                layout['matrix'][bx][by] = {
+                                    'piece_type': piece_type,
+                                    'color': color_str,
+                                    'has_moved': False,
+                                }
+
+                    # Palette click: change selection
+                    for color_str, piece_type, rect in self._palette_rects():
+                        if rect.collidepoint(mx, my):
+                            selected = (color_str, piece_type)
+
+                    # Button clicks
+                    for label, rect in self._button_rects(btn_y, btn_h).items():
+                        if rect.collidepoint(mx, my):
+                            if label == '← Back':
+                                return layout, saved_path
+                            elif label == 'Reset':
+                                layout = self._default_layout()
+                                saved_path = None
+                                status_msg = 'Reset to default starting position'
+                                status_until = pygame.time.get_ticks() + 2500
+                            elif label == 'Save':
+                                self._save(layout)
+                                saved_path = _CUSTOM_LAYOUT_PATH
+                                status_msg = 'Saved to defs/custom_layout.json'
+                                status_until = pygame.time.get_ticks() + 2500
+                            elif label == 'Play':
+                                return layout, saved_path
+
+            self._draw(layout, selected, mouse, btn_y, btn_h,
+                       status_msg if pygame.time.get_ticks() < status_until else '')
+            pygame.display.update()
+            clock.tick(60)
+
+    # ------------------------------------------------------------------
+    # Layout helpers
+    # ------------------------------------------------------------------
+
+    def _default_layout(self):
+        """Return the standard chess starting position as a layout dict."""
+        back_rank = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook']
+        matrix = [[None] * 8 for _ in range(8)]
+        for x in range(8):
+            matrix[x][0] = {'piece_type': back_rank[x], 'color': 'black', 'has_moved': False}
+            matrix[x][1] = {'piece_type': 'pawn',        'color': 'black', 'has_moved': False}
+            matrix[x][6] = {'piece_type': 'pawn',        'color': 'white', 'has_moved': False}
+            matrix[x][7] = {'piece_type': back_rank[x],  'color': 'white', 'has_moved': False}
+        return {'matrix': matrix, 'en_passant_target': None, 'promotion_pending': None}
+
+    def _load_or_default(self):
+        if os.path.exists(_CUSTOM_LAYOUT_PATH):
+            try:
+                with open(_CUSTOM_LAYOUT_PATH) as f:
+                    return json.load(f)
+            except (OSError, json.JSONDecodeError):
+                pass
+        return self._default_layout()
+
+    def _save(self, layout):
+        os.makedirs(os.path.dirname(_CUSTOM_LAYOUT_PATH), exist_ok=True)
+        with open(_CUSTOM_LAYOUT_PATH, 'w') as f:
+            json.dump(layout, f, indent=2)
+
+    # ------------------------------------------------------------------
+    # Drawing
+    # ------------------------------------------------------------------
+
+    def _draw(self, layout, selected, mouse, btn_y, btn_h, status_msg):
+        self.screen.fill(self.BG)
+
+        # Title
+        title = self.title_font.render('Board Layout Editor', True, self.TITLE_COLOR)
+        self.screen.blit(title, (self.PADDING, 8))
+        hint = self.tiny_font.render('Left-click: place  •  Right-click: clear  •  Esc: back',
+                                     True, self.DIM_TEXT)
+        self.screen.blit(hint, (self._panel_x(), 8))
+
+        sq = self._board_sq_size()
+        ox, oy = self._board_origin()
+
+        # Board squares
+        for x in range(8):
+            for y in range(8):
+                color = self.CREAM if (x + y) % 2 == 0 else self.BROWN
+                rect = self._board_sq_rect(x, y)
+                sq_coord = self._board_sq_from_pixel(*mouse)
+                if sq_coord == (x, y):
+                    color = tuple(min(c + 30, 255) for c in color)
+                pygame.draw.rect(self.screen, color, rect)
+
+        # Board pieces
+        piece_labels = {'pawn': 'P', 'rook': 'R', 'knight': 'N',
+                        'bishop': 'B', 'queen': 'Q', 'king': 'K'}
+        for x in range(8):
+            for y in range(8):
+                cell = layout['matrix'][x][y]
+                if cell is None:
+                    continue
+                rect = self._board_sq_rect(x, y)
+                cx, cy = rect.centerx, rect.centery
+                color_key = cell['color']
+                icon = self.piece_icons.get((cell['piece_type'], color_key))
+                if icon:
+                    self.screen.blit(icon, icon.get_rect(center=(cx, cy)))
+                else:
+                    c = Colours.WHITE if color_key == 'white' else Colours.PIECE_BLACK
+                    r = sq // 2 - 2
+                    pygame.draw.circle(self.screen, c, (cx, cy), r)
+                    outline = Colours.BLACK if color_key == 'white' else Colours.WHITE
+                    pygame.draw.circle(self.screen, outline, (cx, cy), r, 2)
+                    lbl = self.small_font.render(piece_labels.get(cell['piece_type'], '?'),
+                                                 True, outline)
+                    self.screen.blit(lbl, lbl.get_rect(center=(cx, cy)))
+
+        # Board border
+        pygame.draw.rect(self.screen, (80, 85, 100),
+                         pygame.Rect(ox, oy, sq * 8, sq * 8), 2)
+
+        # Right panel — palette
+        px = self._panel_x()
+        pw = self.w - px - self.PADDING
+        pygame.draw.rect(self.screen, self.PANEL_BG,
+                         pygame.Rect(px - self.PADDING // 2, oy,
+                                     pw + self.PADDING, btn_y - oy - self.PADDING),
+                         border_radius=4)
+        pal_hdr = self.label_font.render('Palette', True, self.TITLE_COLOR)
+        self.screen.blit(pal_hdr, (px, oy + 6))
+
+        for color_str, piece_type, rect in self._palette_rects():
+            is_sel = selected == (color_str, piece_type)
+            hov    = rect.collidepoint(*mouse)
+            if is_sel:
+                bg = self.HIGH
+                tc = (20, 20, 20)
+            elif hov:
+                bg = self.BTN_HOV
+                tc = self.TEXT
+            else:
+                bg = self.BTN_BG
+                tc = self.TEXT
+            pygame.draw.rect(self.screen, bg, rect, border_radius=5)
+
+            # Mini icon in the palette row
+            icon = self.piece_icons.get((piece_type, color_str))
+            icon_x = rect.left + 4
+            if icon:
+                small = pygame.transform.smoothscale(icon, (24, 24))
+                self.screen.blit(small, small.get_rect(centery=rect.centery, left=icon_x))
+            lbl_text = f"{color_str}  {piece_type}"
+            lbl = self.small_font.render(lbl_text, True, tc)
+            self.screen.blit(lbl, lbl.get_rect(centery=rect.centery, left=icon_x + 28))
+
+        # Bottom buttons
+        btn_colors = {
+            '← Back': self.BTN_BG,
+            'Reset':   self.BTN_RST,
+            'Save':    self.BTN_SAVE,
+            'Play':    self.BTN_PLAY,
+        }
+        for label, rect in self._button_rects(btn_y, btn_h).items():
+            hov = rect.collidepoint(*mouse)
+            base = btn_colors[label]
+            bg = tuple(min(c + 25, 255) for c in base) if hov else base
+            pygame.draw.rect(self.screen, bg, rect, border_radius=8)
+            txt = self.label_font.render(label, True, self.TEXT)
+            self.screen.blit(txt, txt.get_rect(center=rect.center))
+
+        # Status message
+        if status_msg:
+            sm = self.small_font.render(status_msg, True, Colours.GOLD)
+            self.screen.blit(sm, (ox, btn_y - 22))
+
+
 def _start_menu(screen, w, h):
     """
-    Simple title screen: 'Play' or 'Edit Pieces'. Returns 'play' or 'edit'.
+    Simple title screen.  Returns 'play', 'edit_pieces', or 'edit_layout'.
     """
     pygame.display.set_caption('megaChess')
     title_font = pygame.font.Font('freesansbold.ttf', 52)
-    sub_font   = pygame.font.Font('freesansbold.ttf', 20)
-    btn_font   = pygame.font.Font('freesansbold.ttf', 28)
+    sub_font   = pygame.font.Font('freesansbold.ttf', 18)
+    btn_font   = pygame.font.Font('freesansbold.ttf', 24)
     clock = pygame.time.Clock()
-    bw, bh = 240, 56
+    bw, bh = 210, 56
+    gap = 16
+    total_w = bw * 3 + gap * 2
+    x0 = w // 2 - total_w // 2
     btns = {
-        'Play':       pygame.Rect(w // 2 - bw - 16, h * 2 // 3, bw, bh),
-        'Edit Pieces': pygame.Rect(w // 2 + 16,      h * 2 // 3, bw, bh),
+        'Play':         pygame.Rect(x0,            h * 2 // 3, bw, bh),
+        'Edit Pieces':  pygame.Rect(x0 + bw + gap, h * 2 // 3, bw, bh),
+        'Edit Layout':  pygame.Rect(x0 + (bw + gap) * 2, h * 2 // 3, bw, bh),
     }
-    btn_colors = {'Play': (60, 110, 170), 'Edit Pieces': (60, 100, 80)}
+    btn_colors = {
+        'Play':        (60, 110, 170),
+        'Edit Pieces': (60, 100, 80),
+        'Edit Layout': (110, 75, 130),
+    }
+    key_map = {
+        'Play':        'play',
+        'Edit Pieces': 'edit_pieces',
+        'Edit Layout': 'edit_layout',
+    }
 
     while True:
         mx, my = pygame.mouse.get_pos()
@@ -989,16 +1359,20 @@ def _start_menu(screen, w, h):
             if event.type == locals.MOUSEBUTTONDOWN:
                 for label, rect in btns.items():
                     if rect.collidepoint(mx, my):
-                        return 'play' if label == 'Play' else 'edit'
+                        return key_map[label]
             if event.type == locals.KEYDOWN:
                 if event.key == locals.K_RETURN:
                     return 'play'
                 if event.key == locals.K_e:
-                    return 'edit'
+                    return 'edit_pieces'
+                if event.key == locals.K_l:
+                    return 'edit_layout'
 
         screen.fill((25, 28, 38))
         title = title_font.render('megaChess', True, Colours.GOLD)
-        sub   = sub_font.render('Press Enter to play  •  E to edit pieces', True, (160, 165, 175))
+        sub   = sub_font.render(
+            'Enter = play  •  E = edit pieces  •  L = edit layout',
+            True, (160, 165, 175))
         screen.blit(title, title.get_rect(centerx=w // 2, y=h // 4))
         screen.blit(sub,   sub.get_rect(centerx=w // 2,   y=h // 4 + 70))
 
@@ -1020,17 +1394,31 @@ def main():
     w = h = min(info.current_w, info.current_h)
     screen = pygame.display.set_mode((w, h))
 
-    custom_defs = None
+    custom_defs   = None
+    # Load previously saved custom layout, if any
+    custom_layout = None
+    if os.path.exists(_CUSTOM_LAYOUT_PATH):
+        try:
+            with open(_CUSTOM_LAYOUT_PATH) as _f:
+                custom_layout = json.load(_f)
+        except (OSError, json.JSONDecodeError):
+            pass
     while True:
         choice = _start_menu(screen, w, h)
-        if choice == 'edit':
+        if choice == 'edit_pieces':
             defs, saved_path = PieceEditor().run()
             if saved_path:
                 custom_defs = defs
+        elif choice == 'edit_layout':
+            layout, saved_path = BoardLayoutEditor().run()
+            if saved_path:
+                custom_layout = layout
         else:
             game = Game()
             if custom_defs is not None:
                 game.board.pieces_defs = custom_defs
+            if custom_layout is not None:
+                game.board.from_dict(custom_layout)
             game.main()
 
 

--- a/Chess/game.py
+++ b/Chess/game.py
@@ -1243,8 +1243,8 @@ class BoardLayoutEditor:
 
     def _make_preset(self, name):
         """Return a preset layout dict by name."""
-        if name == 'Triangle 8×8':
-            return _preset_triangle()
+        if name == 'Diamond 8×8':
+            return _preset_diamond()
         elif name == 'Hexagon 12×12':
             return _preset_hexagon()
         return _preset_standard()
@@ -1296,7 +1296,7 @@ class BoardLayoutEditor:
 
     def _preset_rects(self, btn_y, btn_h, board_size=8):
         """Return dict of preset_name → pygame.Rect, above the bottom buttons."""
-        names = ['Standard 8×8', 'Triangle 8×8', 'Hexagon 12×12']
+        names = ['Standard 8×8', 'Diamond 8×8', 'Hexagon 12×12']
         sq = self._board_sq_size(board_size)
         ox, _ = self._board_origin()
         total_w = sq * board_size
@@ -1501,35 +1501,44 @@ def _preset_standard():
     return _make_layout(8, matrix)
 
 
-def _preset_triangle():
+def _preset_diamond():
     """
-    Triangle board on 8×8.  Holes where x + y < 7 leave a lower-right triangle
-    (36 playable squares).  White starts along the bottom row and right pawns;
-    Black starts along the right column.
+    Diamond (rhombus) board on 8×8.  Holes where abs(2*x - 7) + abs(2*y - 7) > 10
+    leave a diamond shape (52 playable squares) symmetric about both the
+    horizontal and vertical midlines.
+
+    Playable squares per row:
+      y=0,7 → x=2..5 (4 squares)
+      y=1,6 → x=1..6 (6 squares)
+      y=2..5 → x=0..7 (8 squares)
+
+    White back rank at y=7: rook(2), queen(3), king(4), rook(5)
+    White pawns at y=6: x=1..6
+    Black back rank at y=0: rook(2), queen(3), king(4), rook(5)
+    Black pawns at y=1: x=1..6
     """
     N = 8
-    matrix = [['hole'] * N for _ in range(N)]
-    # Clear holes for the playable triangle
-    for x in range(N):
-        for y in range(N):
-            if x + y >= N - 1:
-                matrix[x][y] = None
 
-    # White back rank at y=7 (all 8 squares are in the triangle)
-    white_back = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook']
-    for x in range(N):
-        matrix[x][7] = {'piece_type': white_back[x], 'color': 'white', 'has_moved': False}
-    # White pawns at y=6, x=1..7 (x=0,y=6 is a hole since 0+6=6 < 7)
-    for x in range(1, N):
+    def is_hole(x, y):
+        return abs(2 * x - 7) + abs(2 * y - 7) > 10
+
+    matrix = [['hole' if is_hole(x, y) else None for y in range(N)] for x in range(N)]
+
+    # White back rank at y=7 (x=2..5 are playable)
+    white_back = {2: 'rook', 3: 'queen', 4: 'king', 5: 'rook'}
+    for x, pt in white_back.items():
+        matrix[x][7] = {'piece_type': pt, 'color': 'white', 'has_moved': False}
+    # White pawns at y=6, x=1..6
+    for x in range(1, 7):
         matrix[x][6] = {'piece_type': 'pawn', 'color': 'white', 'has_moved': False}
 
-    # Black back rank along x=7, y=0..6
-    black_back = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight']
-    for y in range(7):
-        matrix[7][y] = {'piece_type': black_back[y], 'color': 'black', 'has_moved': False}
-    # Black pawns at x=6, y=1..6 (x=6,y=0 is a hole since 6+0=6 < 7)
-    for y in range(1, 7):
-        matrix[6][y] = {'piece_type': 'pawn', 'color': 'black', 'has_moved': False}
+    # Black back rank at y=0 (x=2..5 are playable)
+    black_back = {2: 'rook', 3: 'queen', 4: 'king', 5: 'rook'}
+    for x, pt in black_back.items():
+        matrix[x][0] = {'piece_type': pt, 'color': 'black', 'has_moved': False}
+    # Black pawns at y=1, x=1..6
+    for x in range(1, 7):
+        matrix[x][1] = {'piece_type': 'pawn', 'color': 'black', 'has_moved': False}
 
     return _make_layout(N, matrix)
 

--- a/Chess/positions.py
+++ b/Chess/positions.py
@@ -23,18 +23,21 @@ class PieceMoves:
         "straight": [(1, 0), (-1, 0), (0, 1), (0, -1)],
     }
 
-    def __init__(self, pos, piece_type, piece_color, board_matrix, piece_defs, white_color):
+    def __init__(self, pos, piece_type, piece_color, board_matrix, piece_defs, white_color,
+                 board_size=8):
         self.pos = pos
         self.piece_type = piece_type
         self.piece_color = piece_color
         self.board = board_matrix
         self.defs = piece_defs
         self.is_white = (piece_color == white_color)
+        self.board_size = board_size
         self.legal = []
         self._compute()
 
     def _on_board(self, x, y):
-        if not (0 <= x <= 7 and 0 <= y <= 7):
+        N = self.board_size
+        if not (0 <= x < N and 0 <= y < N):
             return False
         return not self.board[x][y].is_hole
 
@@ -84,7 +87,7 @@ class PieceMoves:
         if extra:
             rows_from_back = rule.get('first_move_start_rows_from_back', 0)
             direction = -1 if self.is_white else 1
-            back_row  = 7 if self.is_white else 0
+            back_row  = self.board_size - 1 if self.is_white else 0
             start_row = back_row + direction * rows_from_back
             if y == start_row:
                 max_steps += extra

--- a/Chess/positions.py
+++ b/Chess/positions.py
@@ -34,7 +34,9 @@ class PieceMoves:
         self._compute()
 
     def _on_board(self, x, y):
-        return 0 <= x <= 7 and 0 <= y <= 7
+        if not (0 <= x <= 7 and 0 <= y <= 7):
+            return False
+        return not self.board[x][y].is_hole
 
     def _occupant(self, x, y):
         return self.board[x][y].occupant

--- a/Chess/tests/test_board.py
+++ b/Chess/tests/test_board.py
@@ -26,6 +26,7 @@ def clear_board(board):
     for x in range(8):
         for y in range(8):
             board.matrix[x][y].occupant = None
+            board.matrix[x][y].is_hole = False
     board.en_passant_target = None
     board.promotion_pending = None
 
@@ -664,6 +665,32 @@ class TestHoleSquares(unittest.TestCase):
         self.board.matrix[5][5].is_hole = True
         d = self.board.to_dict()
         self.assertEqual(d['matrix'][5][5], 'hole')
+
+    def test_castling_blocked_by_hole_in_path(self):
+        """A hole between king and rook prevents castling."""
+        clear_board(self.board)
+        place(self.board, 4, 7, W, 'king')
+        place(self.board, 7, 7, W, 'rook')
+        self.board.matrix[5][7].is_hole = True   # punch a hole in the castling path
+        dests = self.board._castling_destinations((4, 7))
+        self.assertNotIn((6, 7), dests)
+
+    def test_castling_blocked_by_hole_destination(self):
+        """A hole at the king's destination prevents castling."""
+        clear_board(self.board)
+        place(self.board, 4, 7, W, 'king')
+        place(self.board, 7, 7, W, 'rook')
+        self.board.matrix[6][7].is_hole = True   # king would land here
+        dests = self.board._castling_destinations((4, 7))
+        self.assertNotIn((6, 7), dests)
+
+    def test_castling_allowed_when_no_holes(self):
+        """Castling still works normally when there are no holes."""
+        clear_board(self.board)
+        place(self.board, 4, 7, W, 'king')
+        place(self.board, 7, 7, W, 'rook')
+        dests = self.board._castling_destinations((4, 7))
+        self.assertIn((6, 7), dests)
 
 
 if __name__ == '__main__':

--- a/Chess/tests/test_board.py
+++ b/Chess/tests/test_board.py
@@ -506,6 +506,7 @@ class TestBoardSerialisation(unittest.TestCase):
 
     def test_to_dict_has_required_keys(self):
         d = self.board.to_dict()
+        self.assertIn('board_size', d)
         self.assertIn('matrix', d)
         self.assertIn('en_passant_target', d)
         self.assertIn('promotion_pending', d)
@@ -691,6 +692,77 @@ class TestHoleSquares(unittest.TestCase):
         place(self.board, 7, 7, W, 'rook')
         dests = self.board._castling_destinations((4, 7))
         self.assertIn((6, 7), dests)
+
+
+
+# ---------------------------------------------------------------------------
+# Variable board size
+# ---------------------------------------------------------------------------
+
+class TestBoardSize(unittest.TestCase):
+
+    def test_default_board_size_is_8(self):
+        board = Board()
+        self.assertEqual(board.board_size, 8)
+
+    def test_custom_board_size_10(self):
+        board = Board(board_size=10)
+        self.assertEqual(board.board_size, 10)
+
+    def test_matrix_dimensions_match_board_size(self):
+        board = Board(board_size=10)
+        self.assertEqual(len(board.matrix), 10)
+        for col in board.matrix:
+            self.assertEqual(len(col), 10)
+
+    def test_to_dict_serialises_board_size(self):
+        board = Board(board_size=10)
+        d = board.to_dict()
+        self.assertEqual(d['board_size'], 10)
+
+    def test_from_dict_restores_board_size(self):
+        board = Board(board_size=10)
+        d = board.to_dict()
+        board2 = Board()
+        board2.from_dict(d)
+        self.assertEqual(board2.board_size, 10)
+
+    def test_from_dict_restores_10x10_matrix(self):
+        board = Board(board_size=10)
+        d = board.to_dict()
+        board2 = Board()
+        board2.from_dict(d)
+        self.assertEqual(len(board2.matrix), 10)
+        for col in board2.matrix:
+            self.assertEqual(len(col), 10)
+
+    def test_from_dict_old_json_no_board_size_defaults_to_8(self):
+        """Old JSON without board_size field should default to 8."""
+        board = Board()
+        d = board.to_dict()
+        del d['board_size']
+        board2 = Board()
+        board2.from_dict(d)
+        self.assertEqual(board2.board_size, 8)
+
+    def test_to_dict_matrix_dimensions_match_board_size(self):
+        board = Board(board_size=10)
+        d = board.to_dict()
+        self.assertEqual(len(d['matrix']), 10)
+        for col in d['matrix']:
+            self.assertEqual(len(col), 10)
+
+    def test_legal_moves_on_10x10_board(self):
+        """Pieces on a 10×10 board should generate correct moves without index errors."""
+        board = Board(board_size=10)
+        for x in range(10):
+            for y in range(10):
+                board.matrix[x][y].occupant = None
+        rook = Piece(W, 'rook')
+        board.matrix[5][5].occupant = rook
+        moves = board.legal_moves((5, 5))
+        # Rook on empty 10×10 at (5,5) should have 9+9-2 = 16+... actually 9+9-2=16? No: 9 in x + 9 in y = 18 moves
+        self.assertEqual(len(moves), 18)
 
 
 if __name__ == '__main__':

--- a/Chess/tests/test_board.py
+++ b/Chess/tests/test_board.py
@@ -594,5 +594,77 @@ class TestBoardSerialisation(unittest.TestCase):
         self.assertIsNotNone(board2.matrix[0][0].occupant)
 
 
+# ---------------------------------------------------------------------------
+# Hole squares
+# ---------------------------------------------------------------------------
+
+class TestHoleSquares(unittest.TestCase):
+
+    def setUp(self):
+        self.board = Board()
+        clear_board(self.board)
+
+    def test_square_default_is_not_hole(self):
+        self.assertFalse(self.board.matrix[3][3].is_hole)
+
+    def test_to_dict_serialises_hole_as_string(self):
+        self.board.matrix[2][2].is_hole = True
+        d = self.board.to_dict()
+        self.assertEqual(d['matrix'][2][2], 'hole')
+
+    def test_to_dict_empty_square_is_none(self):
+        d = self.board.to_dict()
+        self.assertIsNone(d['matrix'][3][3])
+
+    def test_from_dict_restores_hole_flag(self):
+        self.board.matrix[4][5].is_hole = True
+        d = self.board.to_dict()
+        board2 = Board()
+        board2.from_dict(d)
+        self.assertTrue(board2.matrix[4][5].is_hole)
+
+    def test_from_dict_hole_color_is_hole_colour(self):
+        self.board.matrix[1][1].is_hole = True
+        d = self.board.to_dict()
+        board2 = Board()
+        board2.from_dict(d)
+        self.assertEqual(board2.matrix[1][1].color, Colours.HOLE)
+
+    def test_from_dict_hole_has_no_occupant(self):
+        self.board.matrix[0][0].is_hole = True
+        d = self.board.to_dict()
+        board2 = Board()
+        board2.from_dict(d)
+        self.assertIsNone(board2.matrix[0][0].occupant)
+
+    def test_from_dict_non_hole_squares_unchanged(self):
+        self.board.matrix[3][3].is_hole = True
+        d = self.board.to_dict()
+        board2 = Board()
+        board2.from_dict(d)
+        self.assertFalse(board2.matrix[0][0].is_hole)
+
+    def test_from_dict_backwards_compatible_no_holes(self):
+        """Old JSON without any 'hole' strings loads cleanly."""
+        d = self.board.to_dict()
+        # Confirm no 'hole' entries in default layout dict
+        for col in d['matrix']:
+            for cell in col:
+                self.assertNotEqual(cell, 'hole')
+        board2 = Board()
+        board2.from_dict(d)
+        for x in range(8):
+            for y in range(8):
+                self.assertFalse(board2.matrix[x][y].is_hole)
+
+    def test_hole_square_with_piece_serialises_as_hole(self):
+        """Even if a square somehow has both is_hole and an occupant, hole takes priority."""
+        p = Piece(W, 'rook')
+        self.board.matrix[5][5].occupant = p
+        self.board.matrix[5][5].is_hole = True
+        d = self.board.to_dict()
+        self.assertEqual(d['matrix'][5][5], 'hole')
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Chess/tests/test_game.py
+++ b/Chess/tests/test_game.py
@@ -2000,5 +2000,129 @@ class TestPresets(unittest.TestCase):
         self.assertTrue(board.matrix[0][0].is_hole)
 
 
+
+# ---------------------------------------------------------------------------
+# Board size resize (_resize_layout and +/- controls)
+# ---------------------------------------------------------------------------
+
+class TestResizeLayout(unittest.TestCase):
+
+    def setUp(self):
+        self.editor = make_layout_editor()
+
+    def test_resize_up_increases_board_size(self):
+        layout = self.editor._default_layout()  # 8×8
+        result = self.editor._resize_layout(layout, 10)
+        self.assertEqual(result['board_size'], 10)
+
+    def test_resize_up_matrix_dimensions(self):
+        layout = self.editor._default_layout()
+        result = self.editor._resize_layout(layout, 10)
+        self.assertEqual(len(result['matrix']), 10)
+        for col in result['matrix']:
+            self.assertEqual(len(col), 10)
+
+    def test_resize_up_preserves_existing_cells(self):
+        """Cells within the old bounds are kept."""
+        layout = self.editor._default_layout()
+        layout['matrix'][3][3] = {'piece_type': 'rook', 'color': 'white', 'has_moved': False}
+        result = self.editor._resize_layout(layout, 10)
+        self.assertIsNotNone(result['matrix'][3][3])
+        self.assertEqual(result['matrix'][3][3]['piece_type'], 'rook')
+
+    def test_resize_up_new_cells_are_none(self):
+        """Newly added cells (outside old bounds) are None."""
+        layout = self.editor._default_layout()
+        result = self.editor._resize_layout(layout, 10)
+        self.assertIsNone(result['matrix'][9][9])
+        self.assertIsNone(result['matrix'][8][0])
+        self.assertIsNone(result['matrix'][0][8])
+
+    def test_resize_down_decreases_board_size(self):
+        layout = self.editor._default_layout()
+        result = self.editor._resize_layout(layout, 6)
+        self.assertEqual(result['board_size'], 6)
+
+    def test_resize_down_matrix_dimensions(self):
+        layout = self.editor._default_layout()
+        result = self.editor._resize_layout(layout, 6)
+        self.assertEqual(len(result['matrix']), 6)
+        for col in result['matrix']:
+            self.assertEqual(len(col), 6)
+
+    def test_resize_down_preserves_inner_cells(self):
+        """Cells within the new bounds are kept when shrinking."""
+        layout = self.editor._default_layout()
+        layout['matrix'][2][2] = {'piece_type': 'queen', 'color': 'black', 'has_moved': False}
+        result = self.editor._resize_layout(layout, 6)
+        self.assertIsNotNone(result['matrix'][2][2])
+
+    def test_resize_down_drops_outer_cells(self):
+        """Cells outside the new bounds are gone after shrinking."""
+        layout = self.editor._default_layout()
+        result = self.editor._resize_layout(layout, 6)
+        self.assertEqual(len(result['matrix']), 6)
+        for col in result['matrix']:
+            self.assertEqual(len(col), 6)
+
+    def test_resize_preserves_holes(self):
+        """Hole sentinels within bounds are preserved on resize."""
+        layout = self.editor._default_layout()
+        layout['matrix'][2][2] = 'hole'
+        result = self.editor._resize_layout(layout, 10)
+        self.assertEqual(result['matrix'][2][2], 'hole')
+
+    def test_resize_resets_en_passant(self):
+        """en_passant_target and promotion_pending are reset to None on resize."""
+        layout = self.editor._default_layout()
+        layout['en_passant_target'] = [3, 5]
+        result = self.editor._resize_layout(layout, 10)
+        self.assertIsNone(result['en_passant_target'])
+
+    def test_size_rects_returns_two_rects(self):
+        minus_rect, plus_rect = self.editor._size_rects(8)
+        self.assertIsInstance(minus_rect, pygame.Rect)
+        self.assertIsInstance(plus_rect, pygame.Rect)
+
+    def test_size_rects_distinct_positions(self):
+        minus_rect, plus_rect = self.editor._size_rects(8)
+        self.assertNotEqual(minus_rect.x, plus_rect.x)
+
+    def test_plus_click_increases_size(self):
+        """Clicking + in the run loop increases board_size by 1."""
+        editor = make_layout_editor()
+        layout = editor._default_layout()  # board_size=8
+        _, plus_rect = editor._size_rects(8)
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN, pos=plus_rect.center, button=1)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            result_layout, _ = editor.run()
+        self.assertEqual(result_layout['board_size'], 9)
+
+    def test_minus_click_decreases_size(self):
+        """Clicking − in the run loop decreases board_size by 1."""
+        editor = make_layout_editor()
+        layout_data = editor._default_layout()  # board_size=8
+        minus_rect, _ = editor._size_rects(8)
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN, pos=minus_rect.center, button=1)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            result_layout, _ = editor.run()
+        self.assertEqual(result_layout['board_size'], 7)
+
+    def _make_event(self, etype, **kwargs):
+        ev = mock.MagicMock()
+        ev.type = etype
+        for k, v in kwargs.items():
+            setattr(ev, k, v)
+        return ev
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Chess/tests/test_game.py
+++ b/Chess/tests/test_game.py
@@ -1504,12 +1504,16 @@ class TestBoardLayoutEditorGeometry(unittest.TestCase):
 
     def test_palette_rects_covers_all_combinations(self):
         rects = self.editor._palette_rects()
-        # 2 colours × 6 piece types = 12 entries
-        self.assertEqual(len(rects), 12)
-        colors  = {c for c, _, _ in rects}
-        pieces  = {p for _, p, _ in rects}
+        # 2 colours × 6 piece types + 1 hole tool = 13 entries
+        self.assertEqual(len(rects), 13)
+        piece_rects = [(c, p, r) for c, p, r in rects if c != 'hole']
+        colors  = {c for c, _, _ in piece_rects}
+        pieces  = {p for _, p, _ in piece_rects}
         self.assertEqual(colors, {'white', 'black'})
         self.assertEqual(pieces, set(BoardLayoutEditor.PALETTE_PIECES))
+        # Last entry is the hole tool
+        self.assertEqual(rects[-1][0], 'hole')
+        self.assertEqual(rects[-1][1], 'hole')
 
     def test_button_rects_has_all_buttons(self):
         _, oy = self.editor._board_origin()
@@ -1784,6 +1788,142 @@ class TestBoardLayoutAppliedToBoard(unittest.TestCase):
         for x in range(8):
             for y in range(8):
                 self.assertIsNone(board.matrix[x][y].occupant)
+
+
+class TestBoardLayoutEditorHoles(unittest.TestCase):
+    """Tests for the hole-toggling feature in BoardLayoutEditor."""
+
+    def setUp(self):
+        self.editor = make_layout_editor()
+
+    def _make_event(self, etype, **kwargs):
+        ev = mock.MagicMock()
+        ev.type = etype
+        for k, v in kwargs.items():
+            setattr(ev, k, v)
+        return ev
+
+    def _run_events(self, events, path=None):
+        editor = make_layout_editor()
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', path or '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[events, [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            return editor.run()
+
+    def _click_board_sq(self, bx, by, button=1):
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        ox, oy = editor._board_origin()
+        px = ox + bx * sq + sq // 2
+        py = oy + by * sq + sq // 2
+        return self._make_event(pygame.MOUSEBUTTONDOWN,
+                                pos=(px, py), button=button)
+
+    def _hole_palette_event(self):
+        """Return a click event targeting the hole palette entry."""
+        editor = make_layout_editor()
+        hole_rect = self.editor._palette_rects()[-1][2]  # last entry = hole
+        return self._make_event(pygame.MOUSEBUTTONDOWN,
+                                pos=hole_rect.center, button=1)
+
+    def test_selecting_hole_then_clicking_board_creates_hole(self):
+        """Select hole tool, click an empty square → 'hole' sentinel placed."""
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        ox, oy = editor._board_origin()
+        hole_rect = editor._palette_rects()[-1][2]
+        px = ox + 3 * sq + sq // 2
+        py = oy + 3 * sq + sq // 2
+        sel_ev = self._make_event(pygame.MOUSEBUTTONDOWN,
+                                  pos=hole_rect.center, button=1)
+        click_ev = self._make_event(pygame.MOUSEBUTTONDOWN,
+                                    pos=(px, py), button=1)
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[sel_ev, click_ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            layout, _ = editor.run()
+        self.assertEqual(layout['matrix'][3][3], 'hole')
+
+    def test_clicking_hole_square_again_restores_empty(self):
+        """Clicking a hole square with the hole tool selected toggles it back to None."""
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        ox, oy = editor._board_origin()
+        hole_rect = editor._palette_rects()[-1][2]
+        # Target a clear square in the middle of the board
+        px = ox + 3 * sq + sq // 2
+        py = oy + 3 * sq + sq // 2
+        sel_ev  = self._make_event(pygame.MOUSEBUTTONDOWN, pos=hole_rect.center, button=1)
+        click1  = self._make_event(pygame.MOUSEBUTTONDOWN, pos=(px, py), button=1)
+        click2  = self._make_event(pygame.MOUSEBUTTONDOWN, pos=(px, py), button=1)
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[sel_ev, click1, click2], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            layout, _ = editor.run()
+        self.assertIsNone(layout['matrix'][3][3])
+
+    def test_right_click_clears_hole(self):
+        """Right-clicking a hole square clears it (same as clearing pieces)."""
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        ox, oy = editor._board_origin()
+        hole_rect = editor._palette_rects()[-1][2]
+        px = ox + 4 * sq + sq // 2
+        py = oy + 4 * sq + sq // 2
+        sel_ev = self._make_event(pygame.MOUSEBUTTONDOWN, pos=hole_rect.center, button=1)
+        place_ev  = self._make_event(pygame.MOUSEBUTTONDOWN, pos=(px, py), button=1)
+        clear_ev  = self._make_event(pygame.MOUSEBUTTONDOWN, pos=(px, py), button=3)
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[sel_ev, place_ev, clear_ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            layout, _ = editor.run()
+        self.assertIsNone(layout['matrix'][4][4])
+
+    def test_draw_with_holes_in_layout(self):
+        """_draw() renders a layout that contains hole sentinels without error."""
+        layout = self.editor._default_layout()
+        layout['matrix'][3][3] = 'hole'
+        layout['matrix'][5][5] = 'hole'
+        sq = self.editor._board_sq_size()
+        _, oy = self.editor._board_origin()
+        btn_y = oy + sq * 8 + self.editor.PADDING
+        self.editor._draw(layout, 'hole', (0, 0), btn_y, 40, '')
+
+    def test_draw_hole_palette_entry_selected(self):
+        """_draw() with hole tool selected renders hole palette entry highlighted."""
+        layout = self.editor._default_layout()
+        sq = self.editor._board_sq_size()
+        _, oy = self.editor._board_origin()
+        btn_y = oy + sq * 8 + self.editor.PADDING
+        self.editor._draw(layout, 'hole', (0, 0), btn_y, 40, '')
+
+    def test_hole_layout_applied_to_board(self):
+        """A layout dict with 'hole' values loads correctly into Board."""
+        layout = self.editor._default_layout()
+        layout['matrix'][3][3] = 'hole'
+        board = Board()
+        board.from_dict(layout)
+        self.assertTrue(board.matrix[3][3].is_hole)
+        self.assertEqual(board.matrix[3][3].color, Colours.HOLE)
+
+    def test_hole_board_from_dict_round_trip(self):
+        """Board with holes serialises and deserialises holes correctly."""
+        layout = self.editor._default_layout()
+        layout['matrix'][2][2] = 'hole'
+        board = Board()
+        board.from_dict(layout)
+        d = board.to_dict()
+        board2 = Board()
+        board2.from_dict(d)
+        self.assertTrue(board2.matrix[2][2].is_hole)
 
 
 if __name__ == '__main__':

--- a/Chess/tests/test_game.py
+++ b/Chess/tests/test_game.py
@@ -48,6 +48,7 @@ def make_graphics_stub(square_size=80):
     """Graphics instance with all __init__ state set manually — no display needed."""
     g = object.__new__(Graphics)
     g.square_size = square_size
+    g.board_size = 8
     g.piece_size = square_size // 2
     g.window_size = square_size * 8
     g.button_bar_height = 48
@@ -1622,9 +1623,7 @@ class TestBoardLayoutEditorRun(unittest.TestCase):
 
     def test_back_button_click_exits(self):
         editor = make_layout_editor()
-        sq = editor._board_sq_size()
-        _, oy = editor._board_origin()
-        btn_y = oy + sq * 8 + editor.PADDING
+        btn_y = editor._btn_y()
         back_rect = editor._button_rects(btn_y, 40)['← Back']
         ev = self._make_event(pygame.MOUSEBUTTONDOWN,
                               pos=back_rect.center, button=1)
@@ -1633,9 +1632,7 @@ class TestBoardLayoutEditorRun(unittest.TestCase):
 
     def test_play_button_click_exits(self):
         editor = make_layout_editor()
-        sq = editor._board_sq_size()
-        _, oy = editor._board_origin()
-        btn_y = oy + sq * 8 + editor.PADDING
+        btn_y = editor._btn_y()
         play_rect = editor._button_rects(btn_y, 40)['Play']
         ev = self._make_event(pygame.MOUSEBUTTONDOWN,
                               pos=play_rect.center, button=1)
@@ -1645,9 +1642,7 @@ class TestBoardLayoutEditorRun(unittest.TestCase):
 
     def test_reset_button_click(self):
         editor = make_layout_editor()
-        sq = editor._board_sq_size()
-        _, oy = editor._board_origin()
-        btn_y = oy + sq * 8 + editor.PADDING
+        btn_y = editor._btn_y()
         reset_rect = editor._button_rects(btn_y, 40)['Reset']
         esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
         ev = self._make_event(pygame.MOUSEBUTTONDOWN,
@@ -1662,9 +1657,7 @@ class TestBoardLayoutEditorRun(unittest.TestCase):
 
     def test_save_button_click(self):
         editor = make_layout_editor()
-        sq = editor._board_sq_size()
-        _, oy = editor._board_origin()
-        btn_y = oy + sq * 8 + editor.PADDING
+        btn_y = editor._btn_y()
         save_rect = editor._button_rects(btn_y, 40)['Save']
         esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
         ev = self._make_event(pygame.MOUSEBUTTONDOWN,
@@ -1925,6 +1918,86 @@ class TestBoardLayoutEditorHoles(unittest.TestCase):
         board2 = Board()
         board2.from_dict(d)
         self.assertTrue(board2.matrix[2][2].is_hole)
+
+
+
+# ---------------------------------------------------------------------------
+# Preset functions
+# ---------------------------------------------------------------------------
+
+class TestPresets(unittest.TestCase):
+
+    def setUp(self):
+        from game import _preset_standard, _preset_triangle, _preset_hexagon
+        self._preset_standard = _preset_standard
+        self._preset_triangle = _preset_triangle
+        self._preset_hexagon  = _preset_hexagon
+
+    def test_standard_board_size_is_8(self):
+        layout = self._preset_standard()
+        self.assertEqual(layout['board_size'], 8)
+
+    def test_standard_matrix_is_8x8(self):
+        layout = self._preset_standard()
+        self.assertEqual(len(layout['matrix']), 8)
+        for col in layout['matrix']:
+            self.assertEqual(len(col), 8)
+
+    def test_standard_has_no_holes(self):
+        layout = self._preset_standard()
+        for col in layout['matrix']:
+            for cell in col:
+                self.assertNotEqual(cell, 'hole')
+
+    def test_triangle_board_size_is_8(self):
+        layout = self._preset_triangle()
+        self.assertEqual(layout['board_size'], 8)
+
+    def test_triangle_upper_left_is_hole(self):
+        """(0,0) is a hole since 0+0=0 < 7."""
+        layout = self._preset_triangle()
+        self.assertEqual(layout['matrix'][0][0], 'hole')
+
+    def test_triangle_corner_not_hole(self):
+        """(7,7) must be playable (7+7=14 >= 7)."""
+        layout = self._preset_triangle()
+        self.assertNotEqual(layout['matrix'][7][7], 'hole')
+
+    def test_triangle_loads_into_board(self):
+        layout = self._preset_triangle()
+        board = Board()
+        board.from_dict(layout)
+        self.assertEqual(board.board_size, 8)
+        self.assertTrue(board.matrix[0][0].is_hole)
+        self.assertFalse(board.matrix[7][7].is_hole)
+
+    def test_hexagon_board_size_is_12(self):
+        layout = self._preset_hexagon()
+        self.assertEqual(layout['board_size'], 12)
+
+    def test_hexagon_matrix_is_12x12(self):
+        layout = self._preset_hexagon()
+        self.assertEqual(len(layout['matrix']), 12)
+        for col in layout['matrix']:
+            self.assertEqual(len(col), 12)
+
+    def test_hexagon_corner_is_hole(self):
+        """(0,0) is a hole since 0+0=0 < 3."""
+        layout = self._preset_hexagon()
+        self.assertEqual(layout['matrix'][0][0], 'hole')
+
+    def test_hexagon_center_not_hole(self):
+        """(5,5) should be playable (5+5=10 not < 3, not > 19, not exceeds diagonal)."""
+        layout = self._preset_hexagon()
+        self.assertNotEqual(layout['matrix'][5][5], 'hole')
+
+    def test_hexagon_loads_into_board(self):
+        layout = self._preset_hexagon()
+        board = Board()
+        board.from_dict(layout)
+        self.assertEqual(board.board_size, 12)
+        self.assertEqual(len(board.matrix), 12)
+        self.assertTrue(board.matrix[0][0].is_hole)
 
 
 if __name__ == '__main__':

--- a/Chess/tests/test_game.py
+++ b/Chess/tests/test_game.py
@@ -1928,9 +1928,9 @@ class TestBoardLayoutEditorHoles(unittest.TestCase):
 class TestPresets(unittest.TestCase):
 
     def setUp(self):
-        from game import _preset_standard, _preset_triangle, _preset_hexagon
+        from game import _preset_standard, _preset_diamond, _preset_hexagon
         self._preset_standard = _preset_standard
-        self._preset_triangle = _preset_triangle
+        self._preset_diamond  = _preset_diamond
         self._preset_hexagon  = _preset_hexagon
 
     def test_standard_board_size_is_8(self):
@@ -1949,27 +1949,36 @@ class TestPresets(unittest.TestCase):
             for cell in col:
                 self.assertNotEqual(cell, 'hole')
 
-    def test_triangle_board_size_is_8(self):
-        layout = self._preset_triangle()
+    def test_diamond_board_size_is_8(self):
+        layout = self._preset_diamond()
         self.assertEqual(layout['board_size'], 8)
 
-    def test_triangle_upper_left_is_hole(self):
-        """(0,0) is a hole since 0+0=0 < 7."""
-        layout = self._preset_triangle()
+    def test_diamond_corner_is_hole(self):
+        """(0,0) is a hole: abs(2*0-7)+abs(2*0-7)=14 > 10."""
+        layout = self._preset_diamond()
         self.assertEqual(layout['matrix'][0][0], 'hole')
 
-    def test_triangle_corner_not_hole(self):
-        """(7,7) must be playable (7+7=14 >= 7)."""
-        layout = self._preset_triangle()
-        self.assertNotEqual(layout['matrix'][7][7], 'hole')
+    def test_diamond_center_not_hole(self):
+        """(3,3) is playable: abs(6-7)+abs(6-7)=2 <= 10."""
+        layout = self._preset_diamond()
+        self.assertNotEqual(layout['matrix'][3][3], 'hole')
 
-    def test_triangle_loads_into_board(self):
-        layout = self._preset_triangle()
+    def test_diamond_symmetric_horizontally(self):
+        """Diamond is symmetric about y=3.5: hole(x,0) iff hole(x,7)."""
+        layout = self._preset_diamond()
+        for x in range(8):
+            self.assertEqual(
+                layout['matrix'][x][0] == 'hole',
+                layout['matrix'][x][7] == 'hole',
+            )
+
+    def test_diamond_loads_into_board(self):
+        layout = self._preset_diamond()
         board = Board()
         board.from_dict(layout)
         self.assertEqual(board.board_size, 8)
         self.assertTrue(board.matrix[0][0].is_hole)
-        self.assertFalse(board.matrix[7][7].is_hole)
+        self.assertFalse(board.matrix[3][3].is_hole)
 
     def test_hexagon_board_size_is_12(self):
         layout = self._preset_hexagon()

--- a/Chess/tests/test_game.py
+++ b/Chess/tests/test_game.py
@@ -32,6 +32,7 @@ def clear_board(board):
     for x in range(8):
         for y in range(8):
             board.matrix[x][y].occupant = None
+            board.matrix[x][y].is_hole = False
     board.en_passant_target = None
     board.promotion_pending = None
 

--- a/Chess/tests/test_game.py
+++ b/Chess/tests/test_game.py
@@ -1361,5 +1361,430 @@ class TestWinConditionName(unittest.TestCase):
         self.assertEqual(game._win_condition_name(), 'chess')
 
 
+# ---------------------------------------------------------------------------
+# BoardLayoutEditor
+# ---------------------------------------------------------------------------
+
+from game import BoardLayoutEditor
+import unittest.mock as mock
+
+
+def make_layout_editor():
+    """Instantiate BoardLayoutEditor without opening a real display window."""
+    editor = object.__new__(BoardLayoutEditor)
+    editor.w = 640
+    editor.h = 640
+    editor.screen = pygame.Surface((640, 640))
+    editor.title_font = pygame.font.Font('freesansbold.ttf', 28)
+    editor.label_font = pygame.font.Font('freesansbold.ttf', 18)
+    editor.small_font = pygame.font.Font('freesansbold.ttf', 14)
+    editor.tiny_font  = pygame.font.Font('freesansbold.ttf', 12)
+    editor.piece_icons = {}
+    return editor
+
+
+class TestBoardLayoutEditorDefaultLayout(unittest.TestCase):
+
+    def setUp(self):
+        self.editor = make_layout_editor()
+
+    def test_default_layout_has_matrix(self):
+        layout = self.editor._default_layout()
+        self.assertIn('matrix', layout)
+        self.assertEqual(len(layout['matrix']), 8)
+        self.assertEqual(len(layout['matrix'][0]), 8)
+
+    def test_default_layout_white_pawns_on_row_6(self):
+        layout = self.editor._default_layout()
+        for x in range(8):
+            cell = layout['matrix'][x][6]
+            self.assertIsNotNone(cell)
+            self.assertEqual(cell['piece_type'], 'pawn')
+            self.assertEqual(cell['color'], 'white')
+
+    def test_default_layout_black_pawns_on_row_1(self):
+        layout = self.editor._default_layout()
+        for x in range(8):
+            cell = layout['matrix'][x][1]
+            self.assertIsNotNone(cell)
+            self.assertEqual(cell['piece_type'], 'pawn')
+            self.assertEqual(cell['color'], 'black')
+
+    def test_default_layout_back_rank_white(self):
+        layout = self.editor._default_layout()
+        expected = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook']
+        for x in range(8):
+            cell = layout['matrix'][x][7]
+            self.assertEqual(cell['piece_type'], expected[x])
+            self.assertEqual(cell['color'], 'white')
+
+    def test_default_layout_back_rank_black(self):
+        layout = self.editor._default_layout()
+        expected = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook']
+        for x in range(8):
+            cell = layout['matrix'][x][0]
+            self.assertEqual(cell['piece_type'], expected[x])
+            self.assertEqual(cell['color'], 'black')
+
+    def test_default_layout_middle_rows_empty(self):
+        layout = self.editor._default_layout()
+        for y in range(2, 6):
+            for x in range(8):
+                self.assertIsNone(layout['matrix'][x][y])
+
+    def test_default_layout_no_passant_or_promotion(self):
+        layout = self.editor._default_layout()
+        self.assertIsNone(layout['en_passant_target'])
+        self.assertIsNone(layout['promotion_pending'])
+
+
+class TestBoardLayoutEditorSaveLoad(unittest.TestCase):
+
+    def setUp(self):
+        self.editor = make_layout_editor()
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
+        self.tmp.close()
+        self.path = self.tmp.name
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+
+    def test_save_writes_valid_json(self):
+        layout = self.editor._default_layout()
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', self.path):
+            self.editor._save(layout)
+        with open(self.path) as f:
+            data = json.load(f)
+        self.assertIn('matrix', data)
+
+    def test_load_or_default_returns_default_when_no_file(self):
+        non_existent = self.path + '_missing'
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', non_existent):
+            layout = self.editor._load_or_default()
+        self.assertIsNotNone(layout['matrix'][0][7])  # white rook at (0,7)
+
+    def test_load_or_default_loads_saved_file(self):
+        custom = self.editor._default_layout()
+        # Place a custom piece in an otherwise empty square
+        custom['matrix'][3][3] = {'piece_type': 'queen', 'color': 'white', 'has_moved': False}
+        with open(self.path, 'w') as f:
+            json.dump(custom, f)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', self.path):
+            loaded = self.editor._load_or_default()
+        self.assertEqual(loaded['matrix'][3][3]['piece_type'], 'queen')
+
+    def test_load_or_default_falls_back_on_bad_json(self):
+        with open(self.path, 'w') as f:
+            f.write('NOT JSON')
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', self.path):
+            layout = self.editor._load_or_default()
+        # Should still return a valid default layout
+        self.assertEqual(layout['matrix'][0][7]['piece_type'], 'rook')
+
+
+class TestBoardLayoutEditorGeometry(unittest.TestCase):
+
+    def setUp(self):
+        self.editor = make_layout_editor()
+
+    def test_board_sq_size_is_positive(self):
+        self.assertGreater(self.editor._board_sq_size(), 0)
+
+    def test_board_sq_from_pixel_inside(self):
+        ox, oy = self.editor._board_origin()
+        sq = self.editor._board_sq_size()
+        # Centre of square (2, 3)
+        px = ox + 2 * sq + sq // 2
+        py = oy + 3 * sq + sq // 2
+        self.assertEqual(self.editor._board_sq_from_pixel(px, py), (2, 3))
+
+    def test_board_sq_from_pixel_outside(self):
+        self.assertIsNone(self.editor._board_sq_from_pixel(-10, -10))
+
+    def test_palette_rects_covers_all_combinations(self):
+        rects = self.editor._palette_rects()
+        # 2 colours × 6 piece types = 12 entries
+        self.assertEqual(len(rects), 12)
+        colors  = {c for c, _, _ in rects}
+        pieces  = {p for _, p, _ in rects}
+        self.assertEqual(colors, {'white', 'black'})
+        self.assertEqual(pieces, set(BoardLayoutEditor.PALETTE_PIECES))
+
+    def test_button_rects_has_all_buttons(self):
+        _, oy = self.editor._board_origin()
+        sq = self.editor._board_sq_size()
+        btn_y = oy + sq * 8 + self.editor.PADDING
+        rects = self.editor._button_rects(btn_y, 40)
+        self.assertIn('← Back', rects)
+        self.assertIn('Reset', rects)
+        self.assertIn('Save', rects)
+        self.assertIn('Play', rects)
+
+
+class TestBoardLayoutEditorDraw(unittest.TestCase):
+    """Smoke-test _draw() — verifies it runs without errors for various states."""
+
+    def setUp(self):
+        self.editor = make_layout_editor()
+        self.layout = self.editor._default_layout()
+        sq = self.editor._board_sq_size()
+        _, oy = self.editor._board_origin()
+        self.btn_y = oy + sq * 8 + self.editor.PADDING
+
+    def test_draw_default_layout_no_status(self):
+        self.editor._draw(self.layout, ('white', 'pawn'), (0, 0),
+                          self.btn_y, 40, '')
+
+    def test_draw_with_status_message(self):
+        self.editor._draw(self.layout, ('black', 'queen'), (0, 0),
+                          self.btn_y, 40, 'Saved!')
+
+    def test_draw_with_mouse_over_board(self):
+        ox, oy = self.editor._board_origin()
+        sq = self.editor._board_sq_size()
+        mouse = (ox + sq * 3 + sq // 2, oy + sq * 4 + sq // 2)
+        self.editor._draw(self.layout, ('white', 'rook'), mouse,
+                          self.btn_y, 40, '')
+
+    def test_draw_with_empty_layout(self):
+        empty = self.editor._default_layout()
+        for x in range(8):
+            for y in range(8):
+                empty['matrix'][x][y] = None
+        self.editor._draw(empty, ('white', 'knight'), (0, 0),
+                          self.btn_y, 40, '')
+
+    def test_draw_with_black_piece_fallback(self):
+        layout = self.editor._default_layout()
+        # Force a piece type not in piece_icons (no SVG → fallback path)
+        layout['matrix'][4][4] = {'piece_type': 'rook', 'color': 'black', 'has_moved': False}
+        # piece_icons is empty in the stub, so fallback circle+letter code runs
+        self.editor._draw(layout, ('white', 'pawn'), (0, 0),
+                          self.btn_y, 40, '')
+
+    def test_draw_selected_palette_item_highlighted(self):
+        # No assertion on pixels — just confirm no exception with selected item
+        self.editor._draw(self.layout, ('black', 'bishop'), (0, 0),
+                          self.btn_y, 40, '')
+
+    def test_draw_mouse_hover_over_palette_item(self):
+        # Hit the 'hov' branch in palette rendering (non-selected item under mouse)
+        palette_rects = self.editor._palette_rects()
+        # Hover over the second palette item while first is selected
+        selected = (palette_rects[0][0], palette_rects[0][1])
+        hover_rect = palette_rects[1][2]
+        mouse = hover_rect.center
+        self.editor._draw(self.layout, selected, mouse, self.btn_y, 40, '')
+
+    def test_draw_with_piece_icons_populated(self):
+        # Hit the 'icon' branch for both board pieces and palette items
+        dummy_icon = pygame.Surface((30, 30))
+        self.editor.piece_icons[('pawn', 'white')] = dummy_icon
+        self.editor.piece_icons[('pawn', 'black')] = dummy_icon
+        self.editor._draw(self.layout, ('white', 'pawn'), (0, 0),
+                          self.btn_y, 40, '')
+
+
+class TestBoardLayoutEditorRun(unittest.TestCase):
+    """Test the run() event loop by injecting synthetic pygame events."""
+
+    def _make_event(self, etype, **kwargs):
+        """Create a minimal pygame event object with the given attributes."""
+        ev = mock.MagicMock()
+        ev.type = etype
+        for k, v in kwargs.items():
+            setattr(ev, k, v)
+        return ev
+
+    def _run_with_events(self, events, layout_path=None):
+        """
+        Create a stub editor, patch event.get() to return `events`, then
+        return immediately after ESC is processed (the last event).
+        """
+        editor = make_layout_editor()
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', layout_path or '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', return_value=events), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            return editor.run()
+
+    def test_escape_key_exits_loop(self):
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        layout, saved = self._run_with_events([esc])
+        self.assertIsNone(saved)
+        self.assertIn('matrix', layout)
+
+    def test_back_button_click_exits(self):
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        _, oy = editor._board_origin()
+        btn_y = oy + sq * 8 + editor.PADDING
+        back_rect = editor._button_rects(btn_y, 40)['← Back']
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN,
+                              pos=back_rect.center, button=1)
+        layout, saved = self._run_with_events([ev])
+        self.assertIsNone(saved)
+
+    def test_play_button_click_exits(self):
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        _, oy = editor._board_origin()
+        btn_y = oy + sq * 8 + editor.PADDING
+        play_rect = editor._button_rects(btn_y, 40)['Play']
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN,
+                              pos=play_rect.center, button=1)
+        layout, saved = self._run_with_events([ev])
+        self.assertIsNone(saved)
+        self.assertIn('matrix', layout)
+
+    def test_reset_button_click(self):
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        _, oy = editor._board_origin()
+        btn_y = oy + sq * 8 + editor.PADDING
+        reset_rect = editor._button_rects(btn_y, 40)['Reset']
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN,
+                              pos=reset_rect.center, button=1)
+        # Reset then ESC out
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            layout, saved = editor.run()
+        self.assertIsNone(saved)
+
+    def test_save_button_click(self):
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        _, oy = editor._board_origin()
+        btn_y = oy + sq * 8 + editor.PADDING
+        save_rect = editor._button_rects(btn_y, 40)['Save']
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN,
+                              pos=save_rect.center, button=1)
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as tf:
+            path = tf.name
+        try:
+            with mock.patch('game._CUSTOM_LAYOUT_PATH', path), \
+                 mock.patch('pygame.event.get', side_effect=[[ev], [esc]]), \
+                 mock.patch('pygame.display.update'), \
+                 mock.patch.object(editor, '_draw'):
+                layout, saved = editor.run()
+            self.assertEqual(saved, path)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_left_click_on_board_places_piece(self):
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        ox, oy = editor._board_origin()
+        # Click on square (3, 3)
+        px = ox + 3 * sq + sq // 2
+        py = oy + 3 * sq + sq // 2
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN, pos=(px, py), button=1)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            layout, _ = editor.run()
+        self.assertIsNotNone(layout['matrix'][3][3])
+        self.assertEqual(layout['matrix'][3][3]['piece_type'], 'pawn')
+
+    def test_right_click_on_board_clears_piece(self):
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        ox, oy = editor._board_origin()
+        # Click on square (0, 7) which has a white rook in default layout
+        px = ox + 0 * sq + sq // 2
+        py = oy + 7 * sq + sq // 2
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN, pos=(px, py), button=3)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            layout, _ = editor.run()
+        self.assertIsNone(layout['matrix'][0][7])
+
+    def test_left_click_same_piece_removes_it(self):
+        """Clicking the same piece type on a square removes it."""
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        ox, oy = editor._board_origin()
+        # White pawn is the default selection; row 6 has white pawns
+        px = ox + 2 * sq + sq // 2
+        py = oy + 6 * sq + sq // 2
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN, pos=(px, py), button=1)
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            layout, _ = editor.run()
+        # The pawn at (2, 6) should now be removed
+        self.assertIsNone(layout['matrix'][2][6])
+
+    def test_palette_click_changes_selection(self):
+        """Clicking a palette item changes the selected piece."""
+        editor = make_layout_editor()
+        sq = editor._board_sq_size()
+        _, oy = editor._board_origin()
+        btn_y = oy + sq * 8 + editor.PADDING
+        # Pick the first palette entry (white king)
+        first_rect = editor._palette_rects()[0][2]
+        esc = self._make_event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        ev = self._make_event(pygame.MOUSEBUTTONDOWN,
+                              pos=first_rect.center, button=1)
+        # We can't inspect 'selected' directly from outside, but we confirm no error
+        with mock.patch('game._CUSTOM_LAYOUT_PATH', '/nonexistent/_layout.json'), \
+             mock.patch('pygame.event.get', side_effect=[[ev], [esc]]), \
+             mock.patch('pygame.display.update'), \
+             mock.patch.object(editor, '_draw'):
+            layout, _ = editor.run()
+        self.assertIn('matrix', layout)
+
+
+class TestBoardLayoutAppliedToBoard(unittest.TestCase):
+    """Verify that a custom layout dict can be applied to Board via from_dict."""
+
+    def test_custom_layout_loads_into_board(self):
+        editor = make_layout_editor()
+        layout = editor._default_layout()
+        # Remove all pieces from row 6 (white pawns) and add a rook at (3, 3)
+        for x in range(8):
+            layout['matrix'][x][6] = None
+        layout['matrix'][3][3] = {'piece_type': 'rook', 'color': 'white', 'has_moved': False}
+
+        board = Board()
+        board.from_dict(layout)
+
+        # White pawns on row 6 should be gone
+        for x in range(8):
+            self.assertIsNone(board.matrix[x][6].occupant)
+        # Rook placed at (3, 3)
+        rook = board.matrix[3][3].occupant
+        self.assertIsNotNone(rook)
+        self.assertEqual(rook.piece_type, 'rook')
+        self.assertEqual(rook.color, Colours.WHITE)
+
+    def test_empty_layout_loads_into_board(self):
+        editor = make_layout_editor()
+        layout = editor._default_layout()
+        for x in range(8):
+            for y in range(8):
+                layout['matrix'][x][y] = None
+
+        board = Board()
+        board.from_dict(layout)
+
+        for x in range(8):
+            for y in range(8):
+                self.assertIsNone(board.matrix[x][y].occupant)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Chess/tests/test_positions.py
+++ b/Chess/tests/test_positions.py
@@ -27,6 +27,7 @@ def clear_board(board):
     for x in range(8):
         for y in range(8):
             board.matrix[x][y].occupant = None
+            board.matrix[x][y].is_hole = False
     board.en_passant_target = None
     board.promotion_pending = None
 

--- a/Chess/tests/test_positions.py
+++ b/Chess/tests/test_positions.py
@@ -263,5 +263,95 @@ class TestJumpCapture(unittest.TestCase):
             self.assertTrue(0 <= mx <= 7 and 0 <= my <= 7)
 
 
+# ---------------------------------------------------------------------------
+# Hole squares block moves
+# ---------------------------------------------------------------------------
+
+class TestHoleBlocksMoves(unittest.TestCase):
+
+    def setUp(self):
+        self.board = Board()
+        clear_board(self.board)
+
+    def _moves(self, coord):
+        x, y = coord
+        piece = self.board.matrix[x][y].occupant
+        return PieceMoves(
+            pos=coord,
+            piece_type=piece.piece_type,
+            piece_color=piece.color,
+            board_matrix=self.board.matrix,
+            piece_defs=self.board.pieces_defs,
+            white_color=Colours.WHITE,
+        ).legal
+
+    def test_rook_slide_stops_before_hole(self):
+        """Rook at (3,3) sliding right; hole at (5,3) → cannot reach (5,3) or beyond."""
+        place(self.board, 3, 3, W, 'rook')
+        self.board.matrix[5][3].is_hole = True
+        moves = self._moves((3, 3))
+        # (4,3) is reachable; (5,3) and (6,3) and (7,3) are not
+        self.assertIn((4, 3), moves)
+        self.assertNotIn((5, 3), moves)
+        self.assertNotIn((6, 3), moves)
+        self.assertNotIn((7, 3), moves)
+
+    def test_rook_cannot_land_on_hole(self):
+        """Rook adjacent to a hole cannot land on it."""
+        place(self.board, 3, 3, W, 'rook')
+        self.board.matrix[4][3].is_hole = True
+        moves = self._moves((3, 3))
+        self.assertNotIn((4, 3), moves)
+
+    def test_bishop_slide_stops_before_hole(self):
+        """Bishop sliding diagonally is blocked by a hole."""
+        place(self.board, 3, 3, W, 'bishop')
+        self.board.matrix[5][5].is_hole = True
+        moves = self._moves((3, 3))
+        self.assertIn((4, 4), moves)
+        self.assertNotIn((5, 5), moves)
+        self.assertNotIn((6, 6), moves)
+
+    def test_knight_cannot_jump_to_hole(self):
+        """Knight cannot land on a hole square even with its jump move."""
+        place(self.board, 3, 3, W, 'knight')
+        # A knight at (3,3) can normally reach (4,5)
+        self.board.matrix[4][5].is_hole = True
+        moves = self._moves((3, 3))
+        self.assertNotIn((4, 5), moves)
+
+    def test_king_cannot_step_into_hole(self):
+        """King cannot move to a hole square."""
+        place(self.board, 3, 3, W, 'king')
+        self.board.matrix[4][3].is_hole = True
+        moves = self._moves((3, 3))
+        self.assertNotIn((4, 3), moves)
+
+    def test_pawn_cannot_advance_into_hole(self):
+        """White pawn blocked from moving forward into a hole."""
+        place(self.board, 3, 5, W, 'pawn')
+        self.board.matrix[3][4].is_hole = True
+        moves = self._moves((3, 5))
+        self.assertNotIn((3, 4), moves)
+        self.assertNotIn((3, 3), moves)  # double push also blocked
+
+    def test_queen_blocked_by_hole(self):
+        """Queen's sliding ray is cut off by a hole."""
+        place(self.board, 0, 0, W, 'queen')
+        self.board.matrix[3][0].is_hole = True
+        moves = self._moves((0, 0))
+        self.assertIn((2, 0), moves)
+        self.assertNotIn((3, 0), moves)
+        self.assertNotIn((4, 0), moves)
+
+    def test_non_hole_squares_still_reachable(self):
+        """Holes only block their own square; adjacent non-holes remain reachable."""
+        place(self.board, 3, 3, W, 'rook')
+        self.board.matrix[5][3].is_hole = True
+        moves = self._moves((3, 3))
+        self.assertIn((4, 3), moves)   # one step right — still open
+        self.assertIn((3, 4), moves)   # up direction — unaffected
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Chess/tests/test_win_conditions.py
+++ b/Chess/tests/test_win_conditions.py
@@ -27,6 +27,7 @@ def clear_board(board):
     for x in range(8):
         for y in range(8):
             board.matrix[x][y].occupant = None
+            board.matrix[x][y].is_hole = False
     board.en_passant_target = None
     board.promotion_pending = None
 

--- a/Chess/tests/test_win_conditions.py
+++ b/Chess/tests/test_win_conditions.py
@@ -175,5 +175,69 @@ class TestCheckersWinCondition(unittest.TestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# Hole squares are skipped in win-condition iteration
+# ---------------------------------------------------------------------------
+
+class TestHoleSkippedInWinCheck(unittest.TestCase):
+
+    def setUp(self):
+        self.board = Board()
+        for x in range(8):
+            for y in range(8):
+                self.board.matrix[x][y].occupant = None
+        self.board.en_passant_target = None
+        self.board.promotion_pending = None
+        self.chess_wc = ChessWinCondition()
+        self.checkers_wc = CheckersWinCondition()
+
+    def test_chess_wc_skips_hole_and_detects_stalemate(self):
+        """With only a king that is in check on a mostly-hole board, checkmate is detected."""
+        # Place white king at (4, 4), surround with black rooks to force checkmate
+        place(self.board, 4, 4, W, 'king')
+        place(self.board, 0, 0, B, 'rook')
+        place(self.board, 0, 7, B, 'rook')
+        # Mark all squares except the occupied ones as holes to limit escape routes
+        for x in range(8):
+            for y in range(8):
+                if self.board.matrix[x][y].occupant is None:
+                    self.board.matrix[x][y].is_hole = True
+        game = MockGame(self.board, W)
+        # Should not raise an exception regardless of result
+        result = self.chess_wc.check(game)
+        # Result may be checkmate, stalemate, or check — we just need no crash
+        # and if there's a result it must be a GameResult
+        if result is not None:
+            self.assertIsInstance(result, GameResult)
+
+    def test_chess_wc_hole_squares_produce_no_false_pieces(self):
+        """Hole squares are not treated as occupied by any colour."""
+        place(self.board, 4, 4, W, 'king')
+        place(self.board, 4, 0, B, 'king')
+        # Mark (0,0) as a hole — it should be skipped, not counted as a piece
+        self.board.matrix[0][0].is_hole = True
+        game = MockGame(self.board, W)
+        # Must not raise; win condition should run normally
+        self.chess_wc.check(game)
+
+    def test_checkers_wc_skips_hole_squares(self):
+        """CheckersWinCondition skips holes without raising."""
+        place(self.board, 4, 4, W, 'king')
+        place(self.board, 4, 0, B, 'king')
+        self.board.matrix[0][0].is_hole = True
+        game = MockGame(self.board, W)
+        self.checkers_wc.check(game)  # should not raise
+
+    def test_checkers_wc_hole_does_not_block_win_detection(self):
+        """A hole on the board doesn't prevent checkers win detection."""
+        place(self.board, 4, 4, W, 'king')
+        # No black pieces — black has no moves
+        game = MockGame(self.board, B)
+        self.board.matrix[3][3].is_hole = True
+        result = self.checkers_wc.check(game)
+        self.assertIsNotNone(result)
+        self.assertIn('WHITE WINS', result.message)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Chess/win_conditions.py
+++ b/Chess/win_conditions.py
@@ -56,8 +56,9 @@ class ChessWinCondition(WinCondition):
         current = game.turn
 
         has_safe = False
-        for x in range(8):
-            for y in range(8):
+        N = game.board.board_size
+        for x in range(N):
+            for y in range(N):
                 if game.board.matrix[x][y].is_hole:
                     continue
                 sq = game.board.location((x, y))
@@ -99,8 +100,9 @@ class CheckersWinCondition(WinCondition):
         current = game.turn
 
         has_move = False
-        for x in range(8):
-            for y in range(8):
+        N = game.board.board_size
+        for x in range(N):
+            for y in range(N):
                 if game.board.matrix[x][y].is_hole:
                     continue
                 sq = game.board.location((x, y))

--- a/Chess/win_conditions.py
+++ b/Chess/win_conditions.py
@@ -58,6 +58,8 @@ class ChessWinCondition(WinCondition):
         has_safe = False
         for x in range(8):
             for y in range(8):
+                if game.board.matrix[x][y].is_hole:
+                    continue
                 sq = game.board.location((x, y))
                 if sq.occupant and sq.occupant.color == current:
                     if game.board.legal_moves_safe((x, y)):
@@ -99,6 +101,8 @@ class CheckersWinCondition(WinCondition):
         has_move = False
         for x in range(8):
             for y in range(8):
+                if game.board.matrix[x][y].is_hole:
+                    continue
                 sq = game.board.location((x, y))
                 if sq.occupant and sq.occupant.color == current:
                     if game.board.legal_moves((x, y)):


### PR DESCRIPTION
- New BoardLayoutEditor class: interactive 8×8 board editor where players
  can place/remove any piece (left-click to place, right-click to clear,
  clicking the same piece again removes it) and choose from a colour+type
  palette on the right panel.
- Buttons: ← Back, Reset (restore default), Save (writes
  defs/custom_layout.json), Play (return to main loop with current layout).
- _start_menu updated with a third 'Edit Layout' button (keyboard shortcut L)
  and subtitle updated to reflect all three options.
- main() loads any previously saved custom_layout.json on startup so the
  custom starting position persists across sessions; the layout is applied
  to the board via Board.from_dict() before each new game.
- _CUSTOM_LAYOUT_PATH constant added alongside existing piece/def paths.
- 35 new tests covering default layout, save/load, geometry helpers, draw
  code-paths (including icon and hover branches), and the full run() event
  loop via mocked pygame events; total coverage restored to 81%.

https://claude.ai/code/session_019N3ojTBPksYdnoV8zExe1f